### PR TITLE
Only show session profit HUD while macro is running

### DIFF
--- a/src/main/java/dev/aether/hud/ProfitHudElement.java
+++ b/src/main/java/dev/aether/hud/ProfitHudElement.java
@@ -95,7 +95,8 @@ public class ProfitHudElement extends HudElement {
         return switch (mode) {
             case "lifetime" -> AetherConfig.SHOW_LIFETIME_HUD.get();
             case "daily"    -> AetherConfig.SHOW_DAILY_HUD.get();
-            default         -> AetherConfig.SHOW_SESSION_PROFIT_HUD.get();
+            default         -> AetherConfig.SHOW_SESSION_PROFIT_HUD.get()
+                    && MacroStateManager.isMacroRunning();
         };
     }
     @Override public String  getName()       { return title(); }


### PR DESCRIPTION
Session profit is always showing for me. This is a fix.

dc: meh.lo