### PR TITLE
feat: fixed ping counter to not always say 1ms

### DIFF
--- a/src/main/java/dev/aether/bootstrap/AetherBootstrapHooks.java
+++ b/src/main/java/dev/aether/bootstrap/AetherBootstrapHooks.java
@@ -178,6 +178,9 @@ public final class AetherBootstrapHooks {
 
         default void onParticlePacket(Minecraft minecraft, ClientboundLevelParticlesPacket packet) {
         }
+
+        default void onStatsPacketReceived() {
+        }
     }
 
     private static final ThreadLocal<Integer> DISPLAY_TRANSFORM_SUSPEND_DEPTH = ThreadLocal.withInitial(() -> 0);
@@ -419,5 +422,9 @@ public final class AetherBootstrapHooks {
 
     public static void onParticlePacket(Minecraft minecraft, ClientboundLevelParticlesPacket packet) {
         hooks.onParticlePacket(minecraft, packet);
+    }
+
+    public static void onStatsPacketReceived() {
+        hooks.onStatsPacketReceived();
     }
 }

--- a/src/main/java/dev/aether/bootstrap/AetherPingTickHandler.java
+++ b/src/main/java/dev/aether/bootstrap/AetherPingTickHandler.java
@@ -1,0 +1,19 @@
+package dev.aether.bootstrap;
+
+import dev.aether.config.AetherConfig;
+import dev.aether.util.PingTracker;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+
+public final class AetherPingTickHandler {
+    private AetherPingTickHandler() {
+    }
+
+    public static void register() {
+        ClientTickEvents.END_CLIENT_TICK.register(client -> {
+            if (!AetherConfig.SHOW_WATERMARK_HUD.get() || !AetherConfig.WATERMARK_SHOW_PING.get()) {
+                return;
+            }
+            PingTracker.tick(client);
+        });
+    }
+}

--- a/src/main/java/dev/aether/bootstrap/AetherTickHandlers.java
+++ b/src/main/java/dev/aether/bootstrap/AetherTickHandlers.java
@@ -14,6 +14,7 @@ public final class AetherTickHandlers {
         AetherUpdateTickHandler.register();
         AetherWorldChangeTickHandler.register();
         AetherAutomationTickHandler.register();
+        AetherPingTickHandler.register();
         MovementPlaybackManager.register();
         FreecamManager.register();
         FreelookManager.register();

--- a/src/main/java/dev/aether/feature/LiveAetherBootstrapHooks.java
+++ b/src/main/java/dev/aether/feature/LiveAetherBootstrapHooks.java
@@ -31,6 +31,7 @@ import dev.aether.ui.MainGUI;
 import dev.aether.util.BpsTracker;
 import dev.aether.util.DelayedBlockBreakTracker;
 import dev.aether.util.NickHiderUtils;
+import dev.aether.util.PingTracker;
 import dev.aether.util.ProgrammaticMovementTracker;
 import it.unimi.dsi.fastutil.booleans.BooleanConsumer;
 import net.minecraft.client.KeyMapping;
@@ -324,5 +325,10 @@ public final class LiveAetherBootstrapHooks implements AetherBootstrapHooks.Feat
         if (packet.getParticle().getType() == ParticleTypes.ANGRY_VILLAGER) {
             PestDestroyer.onFireworkParticle(packet.getX(), packet.getY(), packet.getZ());
         }
+    }
+
+    @Override
+    public void onStatsPacketReceived() {
+        PingTracker.onStatsReceived();
     }
 }

--- a/src/main/java/dev/aether/hud/WatermarkHudElement.java
+++ b/src/main/java/dev/aether/hud/WatermarkHudElement.java
@@ -11,8 +11,8 @@ import dev.aether.renderer.NVGRenderer;
 import dev.aether.ui.theme.Theme;
 import dev.aether.ui.util.Fonts;
 import dev.aether.util.BpsTracker;
+import dev.aether.util.PingTracker;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.multiplayer.PlayerInfo;
 
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
@@ -362,7 +362,6 @@ public class WatermarkHudElement extends HudElement {
 
     private static String getPing(Minecraft mc) {
         if (mc.player == null || mc.getConnection() == null) return "---";
-        PlayerInfo info = mc.getConnection().getPlayerInfo(mc.player.getUUID());
-        return info != null ? info.getLatency() + "ms" : "---";
+        return PingTracker.getFormattedPing();
     }
 }

--- a/src/main/java/dev/aether/mixin/MixinClientPacketListenerPing.java
+++ b/src/main/java/dev/aether/mixin/MixinClientPacketListenerPing.java
@@ -1,0 +1,18 @@
+package dev.aether.mixin;
+
+import dev.aether.bootstrap.AetherBootstrapHooks;
+import net.minecraft.client.multiplayer.ClientPacketListener;
+import net.minecraft.network.protocol.game.ClientboundAwardStatsPacket;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ClientPacketListener.class)
+public class MixinClientPacketListenerPing {
+
+    @Inject(method = "handleAwardStats", at = @At("HEAD"))
+    private void onHandleAwardStats(ClientboundAwardStatsPacket packet, CallbackInfo ci) {
+        AetherBootstrapHooks.onStatsPacketReceived();
+    }
+}

--- a/src/main/java/dev/aether/util/PingTracker.java
+++ b/src/main/java/dev/aether/util/PingTracker.java
@@ -1,0 +1,68 @@
+package dev.aether.util;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.protocol.game.ServerboundClientCommandPacket;
+
+/**
+ * Measures real client<->server round-trip latency by timing a vanilla
+ * REQUEST_STATS packet against its ClientboundAwardStatsPacket reply, instead
+ * of relying on the server-reported tab-list latency field (which Hypixel pins
+ * near 0-1ms). Approach mirrors Skytils' Ping feature.
+ */
+public final class PingTracker {
+    private static final long INTERVAL_MS = 5000L;
+    private static final long TIMEOUT_MS = 10_000L;
+
+    private static long lastSentAtNanos = -1L;
+    private static long lastSentAtMillis = 0L;
+    private static double cachedPingMs = -1.0;
+    private static boolean wasConnected = false;
+
+    private PingTracker() {
+    }
+
+    public static void tick(Minecraft client) {
+        if (client.player == null || client.getConnection() == null) {
+            wasConnected = false;
+            return;
+        }
+
+        if (!wasConnected) {
+            wasConnected = true;
+            reset();
+        }
+
+        long now = System.currentTimeMillis();
+
+        // Abandon a request that never got a reply so the counter never freezes.
+        if (lastSentAtNanos > 0 && now - lastSentAtMillis > TIMEOUT_MS) {
+            lastSentAtNanos = -1L;
+        }
+
+        if (lastSentAtNanos > 0 || now - lastSentAtMillis < INTERVAL_MS) {
+            return;
+        }
+
+        lastSentAtMillis = now;
+        lastSentAtNanos = System.nanoTime();
+        client.getConnection().send(new ServerboundClientCommandPacket(ServerboundClientCommandPacket.Action.REQUEST_STATS));
+    }
+
+    public static void onStatsReceived() {
+        if (lastSentAtNanos < 0) {
+            return;
+        }
+        cachedPingMs = (System.nanoTime() - lastSentAtNanos) / 1_000_000.0;
+        lastSentAtNanos = -1L;
+    }
+
+    public static void reset() {
+        lastSentAtNanos = -1L;
+        lastSentAtMillis = 0L;
+        cachedPingMs = -1.0;
+    }
+
+    public static String getFormattedPing() {
+        return cachedPingMs >= 0 ? Math.round(cachedPingMs) + "ms" : "---";
+    }
+}

--- a/src/main/resources/aether.mixins.json
+++ b/src/main/resources/aether.mixins.json
@@ -30,6 +30,7 @@
         "MixinKeyboardHandler",
         "MixinKeyboardInput",
         "MixinClientPacketListener",
+        "MixinClientPacketListenerPing",
         "MixinClientSuggestionProvider",
         "MixinConnectionChannelInitializer",
         "MixinMultiPlayerGameMode",


### PR DESCRIPTION
The watermark HUD ping read the vanilla tab-list latency field, which Hypixel pins near 0-1ms, so it always showed 1ms.

- PingTracker: 5s intervals