### PR TITLE
fix: move night time for sunset pests after /warp garden

### DIFF
--- a/src/main/java/dev/aether/modules/pest/helpers/PestDestroyer.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestDestroyer.java
@@ -1433,33 +1433,30 @@ public class PestDestroyer {
         runtime.roofAotvReturnState = null;
         PathfindingManager.stop();
 
-        restoreSunsetPestsNightThen(client, () -> PestManager.handlePestCleaningFinished(client));
+        PestManager.handlePestCleaningFinished(client);
     }
 
     // -- Helpers --------------------------------------------------------------
 
-    private static void restoreSunsetPestsNightAsync(Minecraft client) {
-        restoreSunsetPestsNightThen(client, null);
+    public static boolean restorePendingSunsetPestsNight(Minecraft client) {
+        return restoreSunsetPestsNight(client);
     }
 
-    private static void restoreSunsetPestsNightThen(Minecraft client, Runnable afterRestore) {
+    private static void restoreSunsetPestsNightAsync(Minecraft client) {
+        MacroWorkerThread.getInstance().submit("PestDestroyer-SunsetPests-Night", () -> restoreSunsetPestsNight(client));
+    }
+
+    private static boolean restoreSunsetPestsNight(Minecraft client) {
         if (!runtime.sunsetPestsRestoreNight) {
-            if (afterRestore != null) {
-                afterRestore.run();
-            }
-            return;
+            return true;
         }
 
         runtime.sunsetPestsRestoreNight = false;
-        MacroWorkerThread.getInstance().submit("PestDestroyer-SunsetPests-Night", () -> {
-            boolean switched = GardenTimeManager.switchToNightTime(client);
-            if (!switched) {
-                ClientUtils.sendDebugMessage("[PestDestroyer] Sunset Pests: failed to switch garden time to night.");
-            }
-            if (afterRestore != null) {
-                client.execute(afterRestore);
-            }
-        });
+        boolean switched = GardenTimeManager.switchToNightTime(client);
+        if (!switched) {
+            ClientUtils.sendDebugMessage("[PestDestroyer] Sunset Pests: failed to switch garden time to night.");
+        }
+        return switched;
     }
 
     public static boolean shouldFinishForAliveCount(Minecraft client, int aliveCount) {

--- a/src/main/java/dev/aether/modules/pest/helpers/PestReturnManager.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestReturnManager.java
@@ -258,6 +258,13 @@ public class PestReturnManager {
                 if (abortFinisherIfNeeded(client, "post-return warp")) {
                     return;
                 }
+
+                setFinishingStage("restore sunset pests night");
+                PestDestroyer.restorePendingSunsetPestsNight(client);
+                if (abortFinisherIfNeeded(client, "restore sunset pests night")) {
+                    return;
+                }
+
                 isReturningFromPestVisitor = true;
                 setFinishingStage("finalize return");
                 ClientUtils.sendDebugMessage("Finisher: Calling finalizeReturnToFarm...");


### PR DESCRIPTION
This way, pest traps and greenhouse can keep the daytime overbloom bonus