### PR TITLE
feat: add UI scale slider to theme options

### DIFF
--- a/src/main/java/dev/aether/feature/ClientFeatureBootstrap.java
+++ b/src/main/java/dev/aether/feature/ClientFeatureBootstrap.java
@@ -20,6 +20,7 @@ import dev.aether.modules.visuals.StreamerModeManager;
 import dev.aether.notification.NotificationManager;
 import dev.aether.renderer.FunRenderer;
 import dev.aether.renderer.PositionHighlighter;
+import dev.aether.ui.MainGUI;
 import dev.aether.ui.theme.Theme;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents;
 import net.fabricmc.fabric.api.client.rendering.v1.level.LevelRenderEvents;
@@ -42,6 +43,7 @@ public final class ClientFeatureBootstrap {
         AetherConfig.init();
         FailsafeSoundManager.init();
         Theme.loadTheme();
+        MainGUI.uiScale = Theme.UI_SCALE; // apply persisted GUI scale (Theme is the source of truth)
         ProfitManager.loadLifetime();
         ProfitManager.loadDaily();
         MacroStateManager.syncFromConfig();

--- a/src/main/java/dev/aether/ui/MainGUI.java
+++ b/src/main/java/dev/aether/ui/MainGUI.java
@@ -106,7 +106,9 @@ public class MainGUI extends NVGScreen {
      * Scale multiplier for the entire menu.
      * 1.0 = every layout unit is exactly 1 physical pixel.
      * Increase to make the menu larger, decrease to shrink it.
-     * Wire to a slider in the Settings tab once that exists.
+     * Persisted value lives in {@link dev.aether.ui.theme.Theme#UI_SCALE} (the source of truth);
+     * MainGUI syncs this from it each frame in syncFrameLayoutForWindowSize, except while a slider
+     * is being dragged (so the UI Scale slider can't feed back). Edit via the slider in Theme Options.
      */
     public static float uiScale = 1.5f;
     public static float uiTextScale = 1;
@@ -2224,6 +2226,12 @@ public class MainGUI extends NVGScreen {
     }
 
     private void syncFrameLayoutForWindowSize(float prevPhysW, float prevPhysH) {
+        // Apply the persisted GUI scale, but hold it steady while a slider is being dragged: the
+        // UI Scale slider lives inside this panel, so rescaling mid-drag would shift the slider's
+        // own coordinate space under the cursor and run the value away to max.
+        if (dragSetting == null && dragRangeSetting == null) {
+            uiScale = Theme.UI_SCALE;
+        }
         boolean sizeChanged = context.layout.lastWidth != width
                 || context.layout.lastHeight != height
                 || Math.abs(context.layout.lastPixelRatio - pr) > 0.001f

--- a/src/main/java/dev/aether/ui/providers/settings/ThemeOptionsSettingsRegistryProvider.java
+++ b/src/main/java/dev/aether/ui/providers/settings/ThemeOptionsSettingsRegistryProvider.java
@@ -28,6 +28,15 @@ public final class ThemeOptionsSettingsRegistryProvider extends AbstractSettings
                             Theme.saveTheme();
                         })
                         .withDecimals(0).withSuffix("ms"))
+                .add(new SliderSetting("UI Scale", Theme.UI_SCALE_MIN, Theme.UI_SCALE_MAX,
+                        () -> Theme.UI_SCALE,
+                        value -> {
+                            // Only update the persisted value; MainGUI applies it to uiScale each
+                            // frame (paused during the drag) so the slider can't feed back to max.
+                            Theme.UI_SCALE = value;
+                            Theme.saveTheme();
+                        })
+                        .withDecimals(2).withSuffix("x"))
                 .add(new ActionSetting("Export Theme (Copy)", () -> {
                     String json = Theme.exportJson();
                     Minecraft.getInstance().keyboardHandler.setClipboard(json);
@@ -36,6 +45,7 @@ public final class ThemeOptionsSettingsRegistryProvider extends AbstractSettings
                     String json = Minecraft.getInstance().keyboardHandler.getClipboard();
                     if (json != null && !json.isBlank()) {
                         Theme.importJson(json);
+                        MainGUI.uiScale = Theme.UI_SCALE; // apply imported scale to the live panel
                         Theme.saveTheme();
                     }
                 })));

--- a/src/main/java/dev/aether/ui/theme/Theme.java
+++ b/src/main/java/dev/aether/ui/theme/Theme.java
@@ -168,6 +168,11 @@ public class Theme {
     /** Target animation time for GUI components in milliseconds. */
     public static float ANIM_TIME_MS = 250f;
 
+    public static final float UI_SCALE_MIN = 0.5f;
+    public static final float UI_SCALE_MAX = 3.0f;
+    /** Global scale of the /aether GUI panel (1.0 = pixel-perfect). Mirrored into MainGUI.uiScale at load. */
+    public static float UI_SCALE = 1.5f;
+
     /** Extra vertical spacing between settings within a module card (px). */
     public static int SETTING_SPACING = 4;
 
@@ -270,6 +275,7 @@ public class Theme {
         }
         obj.addProperty("animSpeed", ANIM_TIME_MS);
         obj.addProperty("settingSpacing", SETTING_SPACING);
+        obj.addProperty("uiScale", UI_SCALE);
         JsonArray rainbowArr = new JsonArray();
         for (String s : rainbowEntries) rainbowArr.add(s);
         obj.add("rainbowEntries", rainbowArr);
@@ -298,6 +304,7 @@ public class Theme {
             }
             if (obj.has("animSpeed"))     ANIM_TIME_MS    = parseAnimationTime(obj.get("animSpeed").getAsFloat());
             if (obj.has("settingSpacing")) SETTING_SPACING = obj.get("settingSpacing").getAsInt();
+            if (obj.has("uiScale"))       UI_SCALE        = Math.max(UI_SCALE_MIN, Math.min(UI_SCALE_MAX, obj.get("uiScale").getAsFloat()));
             rainbowEntries.clear();
             if (obj.has("rainbowEntries")) {
                 obj.get("rainbowEntries").getAsJsonArray()
@@ -320,6 +327,7 @@ public class Theme {
         }
         obj.addProperty("animSpeed", ANIM_TIME_MS);
         obj.addProperty("settingSpacing", SETTING_SPACING);
+        obj.addProperty("uiScale", UI_SCALE);
         JsonArray rainbowArr2 = new JsonArray();
         for (String s : rainbowEntries) rainbowArr2.add(s);
         obj.add("rainbowEntries", rainbowArr2);
@@ -343,6 +351,7 @@ public class Theme {
             }
             if (obj.has("animSpeed"))     ANIM_TIME_MS    = parseAnimationTime(obj.get("animSpeed").getAsFloat());
             if (obj.has("settingSpacing")) SETTING_SPACING = obj.get("settingSpacing").getAsInt();
+            if (obj.has("uiScale"))       UI_SCALE        = Math.max(UI_SCALE_MIN, Math.min(UI_SCALE_MAX, obj.get("uiScale").getAsFloat()));
             rainbowEntries.clear();
             if (obj.has("rainbowEntries")) {
                 obj.get("rainbowEntries").getAsJsonArray()


### PR DESCRIPTION
Adds a **UI Scale** slider to the Theme Options page so the `/aether` GUI can be resized. Previously `MainGUI.uiScale` was a hardcoded `1.5f` with no way to change it in-client.

- New `Theme.UI_SCALE` (0.5–3.0, default 1.5), persisted alongside the other theme values in `saveTheme` / `loadTheme` / `exportJson` / `importJson`.
- `MainGUI` syncs `uiScale` from `Theme.UI_SCALE` each frame in `syncFrameLayoutForWindowSize`, **except while a slider is being dragged**. The UI Scale slider lives inside the panel it resizes, so applying the new scale live mid-drag would shift the slider's own coordinate space under the cursor and run the value straight to max. It applies on release instead.
- Default stays `1.5`, so existing users see no change until they touch the slider.

Tested in-game on 26.1.2: dragging rescales the panel and the value persists across restarts.
