### PR TITLE
fix: stop visitor macro pathing to non-visitor NPCs

### DIFF
--- a/src/main/java/dev/aether/modules/visitor/VisitorsMacro.java
+++ b/src/main/java/dev/aether/modules/visitor/VisitorsMacro.java
@@ -584,7 +584,9 @@ public class VisitorsMacro {
                 }
 
                 if (foundVisitorsHeader) {
-                    if (clean.isEmpty() || clean.contains("Next Visitor") || names.size() >= 5) {
+                    // Visitor name lines never contain a colon; any ':' line (e.g. "Next Visitor:"
+                    // or the following tab section) ends the block so we don't grab non-visitor NPCs.
+                    if (clean.isEmpty() || clean.contains(":") || names.size() >= 5) {
                         break;
                     }
                     String name = clean.replace("NEW!", "").trim();


### PR DESCRIPTION
The visitor macro would sometimes path to non-visitor NPCs (e.g. Sam).

**Cause:** `getVisitorNamesFromTab` reads names after the "Visitors:" tab header until it hits an empty line or "Next Visitor". When the tab list has no blank separator before the following section, it over-read into non-visitor entries, and `findVisitorEntity` then walked to whatever matched by name.

**Fix:** bound the visitor block at the first line containing `:` — every tab section header has one, and visitor name lines never do — so parsing stops at the next section instead of spilling into it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
