### PR TITLE
feat: allow configuring multiple plots for discoless mode

### DIFF
--- a/src/main/java/dev/aether/config/AetherConfig.java
+++ b/src/main/java/dev/aether/config/AetherConfig.java
@@ -445,7 +445,8 @@ public final class AetherConfig {
         public static final BooleanEntry PEST_DISCO_DESTINATION_MODE = Config.bool("pestDiscoDestinationMode", false);
         public static final StringEntry PEST_DISCO_DESTINATION_PLOT = Config.string("pestDiscoDestinationPlot", "0");
         public static final BooleanEntry PEST_DISCOLESS_MODE = Config.bool("pestDiscolessMode", false);
-        public static final StringEntry PEST_DISCOLESS_PLOT = Config.string("pestDiscolessPlot", "0");
+        public static final ListEntry<String> PEST_DISCOLESS_PLOT = Config.list("Discoless plot", 
+                        Arrays.asList("1", "2", "3"), String.class);        
         public static final BooleanEntry PEST_AOTV_BETWEEN = Config.bool("pestAotvBetween", false);
         public static final BooleanEntry PEST_AOTV_CONFIRM_BETWEEN = Config.bool("pestAotvConfirmBetween", false);
         public static final IntEntry PEST_AOTV_DELAY_MIN = Config.integer("pestAotvDelayMin", 150).range(100, 250);

--- a/src/main/java/dev/aether/config/AetherConfig.java
+++ b/src/main/java/dev/aether/config/AetherConfig.java
@@ -446,7 +446,7 @@ public final class AetherConfig {
         public static final StringEntry PEST_DISCO_DESTINATION_PLOT = Config.string("pestDiscoDestinationPlot", "0");
         public static final BooleanEntry PEST_DISCOLESS_MODE = Config.bool("pestDiscolessMode", false);
         public static final ListEntry<String> PEST_DISCOLESS_PLOT = Config.list("Discoless plot", 
-                        Arrays.asList("1", "2", "3"), String.class);        
+                        Arrays.asList("0"), String.class);
         public static final BooleanEntry PEST_AOTV_BETWEEN = Config.bool("pestAotvBetween", false);
         public static final BooleanEntry PEST_AOTV_CONFIRM_BETWEEN = Config.bool("pestAotvConfirmBetween", false);
         public static final IntEntry PEST_AOTV_DELAY_MIN = Config.integer("pestAotvDelayMin", 150).range(100, 250);

--- a/src/main/java/dev/aether/modules/pest/helpers/PestDestroyer.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestDestroyer.java
@@ -8,7 +8,7 @@ import dev.aether.macro.MacroWorkerThread;
 import dev.aether.modules.failsafe.FailsafeManager;
 import dev.aether.modules.rotation.RotationManager;
 import dev.aether.util.ClientUtils;
-
+import dev.aether.modules.pest.helpers.PestDiscoDestinationManager.Mode;
 import net.minecraft.client.Minecraft;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
@@ -1379,11 +1379,15 @@ public class PestDestroyer {
     }
 
     private static void trustConfirmedDiscoDestination() {
+        if (PestDiscoDestinationManager.getMode() == Mode.DISCOLESS) {
+            return;
+        }
+        
         runtime.navigation.discoTargetReached = true;
         runtime.navigation.trustedPlot = PestDiscoDestinationManager.getConfiguredPlot();
         runtime.navigation.trustedPlotExpiresAt = System.currentTimeMillis() + 120_000;
     }
-
+    
     private static boolean lockDiscoDestinationIfCurrentPlot(Minecraft client) {
         if (!isOnDiscoDestinationPlot(client)
                 || runtime.state == State.TELEPORT_TO_PLOT

--- a/src/main/java/dev/aether/modules/pest/helpers/PestDiscoDestinationManager.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestDiscoDestinationManager.java
@@ -4,7 +4,8 @@ import dev.aether.config.AetherConfig;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
-
+import java.util.List;
+import java.util.ArrayList;
 /**
  * Resolves the hold-destination plot: a plot the destroyer teleports to, holds
  * position on, and finishes on after a single kill. Disco holds at the plot-TP
@@ -28,7 +29,7 @@ public final class PestDiscoDestinationManager {
             return Mode.DISCO;
         }
         if (AetherConfig.PEST_DISCOLESS_MODE.get()
-                && isUsablePlot(AetherConfig.PEST_DISCOLESS_PLOT.get())) {
+                && isUsableDiscolessPlots(AetherConfig.PEST_DISCOLESS_PLOT.get())) {
             return Mode.DISCOLESS;
         }
         return Mode.NONE;
@@ -50,15 +51,25 @@ public final class PestDiscoDestinationManager {
     public static String getConfiguredPlot() {
         return switch (getMode()) {
             case DISCO -> normalizePlot(AetherConfig.PEST_DISCO_DESTINATION_PLOT.get());
-            case DISCOLESS -> normalizePlot(AetherConfig.PEST_DISCOLESS_PLOT.get());
+            case DISCOLESS -> "";
             case NONE -> "";
         };
     }
 
     public static boolean matchesPlot(String plot) {
-        return isConfigured() && normalizePlot(plot).equals(getConfiguredPlot());
-    }
+    if (getMode() == Mode.DISCOLESS) {
+        String normalizedPlot = normalizePlot(plot);
 
+        for (String configuredPlot : normalizePlotForDiscoless(AetherConfig.PEST_DISCOLESS_PLOT.get())) {
+            if (normalizedPlot.equals(configuredPlot)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+    return isConfigured() && normalizePlot(plot).equals(getConfiguredPlot());
+}
     public static boolean shouldForcePlotTeleport(String plot) {
         return matchesPlot(plot);
     }
@@ -116,4 +127,28 @@ public final class PestDiscoDestinationManager {
         String digits = plot.trim().replaceAll("\\D", "");
         return digits.isEmpty() ? plot.trim() : digits;
     }
+    
+    public static List<String> normalizePlotForDiscoless(List<String> plotdiscoless) {
+    List<String> normalizedPlots = new ArrayList<>();
+
+    for (String plot : plotdiscoless) {
+        if (plot == null) {
+            continue;
+        }
+        String digits = plot.trim().replaceAll("\\D", "");
+        if (digits.isEmpty() || digits.equals("0")) {
+            continue;
+        }
+        normalizedPlots.add(digits);
+        }
+
+    return normalizedPlots;
+    }
+
+    public static boolean isUsableDiscolessPlots(List<String> plots) {
+        List<String> normalized = normalizePlotForDiscoless(plots);
+        return !normalized.isEmpty();
+    }
 }
+    
+    

--- a/src/main/java/dev/aether/modules/pest/helpers/PestEtherwarpEntryManager.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestEtherwarpEntryManager.java
@@ -7,7 +7,6 @@ import dev.aether.modules.failsafe.FailsafeManager;
 import dev.aether.modules.gear.GearManager;
 import dev.aether.modules.pathfinding.etherwarp.EtherwarpHelper;
 import dev.aether.util.ClientUtils;
-
 import net.minecraft.client.Minecraft;
 import net.minecraft.world.level.ClipContext;
 import net.minecraft.world.phys.BlockHitResult;
@@ -26,7 +25,6 @@ import net.minecraft.world.phys.Vec3;
 final class PestEtherwarpEntryManager {
 
     static final int MAX_ATTEMPTS = 2;
-
     private static final double LANDING_TOLERANCE = 1.5;
     private static final double POSITION_CHANGE_EPSILON = 0.1;
     private static final long PLOT_TP_COOLDOWN_GUARD_MS = 1200L;
@@ -179,7 +177,7 @@ final class PestEtherwarpEntryManager {
         runtime.resetEtherwarpEntry();
         runtime.etherwarpEntryAttempts = 0;
         runtime.navigation.discoTargetReached = true;
-        runtime.navigation.trustedPlot = PestDiscoDestinationManager.getConfiguredPlot();
+        runtime.navigation.trustedPlot = ClientUtils.getCurrentPlot();
         runtime.navigation.trustedPlotExpiresAt = System.currentTimeMillis() + 120_000;
         PestDestroyer.setState(PestDestroyer.State.DISCO_SPIN);
     }

--- a/src/main/java/dev/aether/ui/providers/modules/PestManagerRegistryProvider.java
+++ b/src/main/java/dev/aether/ui/providers/modules/PestManagerRegistryProvider.java
@@ -119,11 +119,11 @@ public final class PestManagerRegistryProvider extends AbstractModulesRegistryPr
                             AetherConfig.PEST_DISCOLESS_MODE.set(v);
                             AetherConfig.save();
                         })
-                .add(new TextSetting("Discoless Plot", "Plot number (e.g. 2)",
+                .add(new ListSetting("Discoless Plot", "Add plot name",
                         () -> AetherConfig.PEST_DISCOLESS_PLOT.get(),
                         v -> {
-                            AetherConfig.PEST_DISCOLESS_PLOT.set(v);
-                            AetherConfig.save();
+                        AetherConfig.PEST_DISCOLESS_PLOT.set(v);
+                        AetherConfig.save();
                         })));
 
         groups.add(SettingGroup.of(


### PR DESCRIPTION
Support multiple configured plots in discoless mode

Because pests can spawn on different plots even if one plot has already been sprayed, many players duplicate their discoless farm design across multiple plots. This allows pests to be cleaned more quickly, even when they spawn outside the sprayed plot. To support this setup, I added a feature that allows configuring multiple plots for the discoless pest-cleaning workflow.