### PR TITLE
fix: rewarp fly-back stuck recovery and precise landing

### DIFF
--- a/src/main/java/dev/aether/modules/pathfinding/PathfindingManager.java
+++ b/src/main/java/dev/aether/modules/pathfinding/PathfindingManager.java
@@ -60,8 +60,14 @@ public final class PathfindingManager {
     private static final double ETHERWARP_WALK_ASSIST_GOAL_TOLERANCE = 0.2;
     private static final int ETHERWARP_WALK_ASSIST_MAX_CANDIDATES = 12;
     private static final int ETHERWARP_REPATH_MAX_RETRIES = 3;
+    // A fly that FINISHED further than this from the goal (e.g. off a partial
+    // path) is not treated as having reached it.
+    private static final double FLY_GOAL_REACHED_DIST = 3.5;
 
     private static volatile boolean navigating = false;
+    // True only when the last fly navigation actually reached its goal. Any other
+    // ending (stall/FAILED, no path, abort) leaves this false so callers can recover.
+    private static volatile boolean flyReachedGoal = false;
     private static volatile int goalX, goalY, goalZ;
     private static volatile NavigationMode activeMode = NavigationMode.NONE;
     private static Entity rotationTarget = null;
@@ -184,7 +190,16 @@ public final class PathfindingManager {
                 mc.player.onUpdateAbilities();
             }
             flyExecutor.tick(mc);
-            if (flyExecutor.getState() == FlyExecutor.State.FINISHED) {
+            FlyExecutor.State postState = flyExecutor.getState();
+            if (postState == FlyExecutor.State.FINISHED || postState == FlyExecutor.State.FAILED) {
+                double goalDx = mc.player.getX() - (goalX + 0.5);
+                double goalDz = mc.player.getZ() - (goalZ + 0.5);
+                double horizDistToGoal = Math.sqrt(goalDx * goalDx + goalDz * goalDz);
+                flyReachedGoal = postState == FlyExecutor.State.FINISHED
+                        && horizDistToGoal <= FLY_GOAL_REACHED_DIST;
+                ClientUtils.sendDebugMessage(String.format(
+                        "fly end: %s, %.1f blocks from goal (reached=%s)",
+                        postState, horizDistToGoal, flyReachedGoal));
                 navigating = false;
                 activeMode = NavigationMode.NONE;
                 clearTransientDebugRenderingIfActive();
@@ -495,6 +510,9 @@ public final class PathfindingManager {
 
     public static boolean isNavigating() { return navigating; }
 
+    /** True when the most recent fly navigation reached its goal (vs stalled/failed/aborted). */
+    public static boolean lastFlyReachedGoal() { return flyReachedGoal; }
+
     public static boolean isWalkSneakLatched() {
         walkSneakLatched = executor.isSneakLatched();
         return walkSneakLatched;
@@ -605,6 +623,10 @@ public final class PathfindingManager {
         navigating = true;
         activeMode = fly ? NavigationMode.FLY : NavigationMode.WALK;
         currentEtherwarpPathfinder = null;
+        // Reset before any async result can land; only a true FINISHED sets this back on.
+        if (fly) {
+            flyReachedGoal = false;
+        }
 
         // Create checker once; reused for solid-check, pathfinding, and smoothing.
         final WalkabilityChecker sharedChecker = mc.level != null ? new WalkabilityChecker(mc.level) : null;
@@ -1251,6 +1273,10 @@ public final class PathfindingManager {
                     false);
         }
 
+        Node lastWp = smoothed.get(smoothed.size() - 1);
+        ClientUtils.sendDebugMessage("fly path final wp: (" + lastWp.position.flooredX()
+                + ", " + lastWp.position.flooredY() + ", " + lastWp.position.flooredZ()
+                + "), goal (" + x + ", " + y + ", " + z + ")");
         flyExecutor.start(smoothed, x, y, z);
     }
 

--- a/src/main/java/dev/aether/modules/pathfinding/execution/FlyExecutor.java
+++ b/src/main/java/dev/aether/modules/pathfinding/execution/FlyExecutor.java
@@ -32,7 +32,7 @@ import net.minecraft.world.phys.Vec3;
 public final class FlyExecutor {
 
     public enum State {
-        IDLE, FLYING, DECELERATING, FINISHED
+        IDLE, FLYING, DECELERATING, FINISHED, FAILED
     }
 
     // How close to a waypoint counts as "reached" (horizontal + vertical)
@@ -43,6 +43,11 @@ public final class FlyExecutor {
     // Stuck timers
     private static final long STUCK_CLIMB_MS = 1500;
     private static final long STUCK_ABORT_MS = 3000;
+    // Net-progress stall detection. The per-tick displacement check above cannot
+    // catch oscillation (a bouncing player keeps moving >0.15/tick yet never gets
+    // closer to the goal), so we also track how close to the goal we have ever got.
+    private static final double GOAL_PROGRESS_EPSILON = 0.2;
+    private static final long NO_PROGRESS_ABORT_MS = 3000;
     // How far ahead to raycast for block detection (blocks)
     private static final double RAY_DIST = 2.5;
     private static final long ROTATION_DURATION_MS = 550L;
@@ -60,6 +65,12 @@ public final class FlyExecutor {
     private long decelStartTime = 0;
     private int ticksSinceLastMove = 0;
     private static final int TICKS_FOR_STUCK = 15; // ~750ms at 20 tps
+
+    /** Net distance-to-goal progress (catches oscillation the per-tick check misses) */
+    private double bestDistToGoal = Double.MAX_VALUE;
+    private long lastGoalProgressTime;
+    /** Times we've resumed flying after braking left us short of the goal */
+    private int decelResumes = 0;
 
     private Runnable onFinished;
     private boolean usePitchControl = false;
@@ -85,6 +96,9 @@ public final class FlyExecutor {
         this.lastProgressTime = System.currentTimeMillis();
         this.lastPosCheck = Vec3.ZERO;
         this.ticksSinceLastMove = 0;
+        this.bestDistToGoal = Double.MAX_VALUE;
+        this.lastGoalProgressTime = System.currentTimeMillis();
+        this.decelResumes = 0;
         this.onFinished = onFinished;
         this.usePitchControl = false;
         this.useLookTargetRotation = false;
@@ -92,6 +106,8 @@ public final class FlyExecutor {
         this.finalWaypointReach = REACH;
         this.goalStopThreshold = STOP_THRESH;
         state = State.FLYING;
+        ClientUtils.sendDebugMessage("fly start: " + this.path.size() + " wps, goal ("
+                + goalX + ", " + goalY + ", " + goalZ + ")");
     }
 
     public void setPitchControl(float pitch) {
@@ -190,6 +206,22 @@ public final class FlyExecutor {
         Vec3 goal = new Vec3(goalX + 0.5, goalY + 0.15, goalZ + 0.5);
         double distToGoal = pos.distanceTo(goal);
 
+        // -- Net-progress stall detection -----------------------------------
+        // Fail if we haven't got meaningfully closer to the goal for a while.
+        // This is what catches oscillating "stuck between two positions": the
+        // per-tick displacement check never fires because we keep moving.
+        if (distToGoal < bestDistToGoal - GOAL_PROGRESS_EPSILON) {
+            bestDistToGoal = distToGoal;
+            lastGoalProgressTime = System.currentTimeMillis();
+        } else if (System.currentTimeMillis() - lastGoalProgressTime > NO_PROGRESS_ABORT_MS) {
+            ClientUtils.sendMessage(String.format(
+                    "§cFly not progressing, recovering. (wp %d/%d, dist %.1f, pos %.1f %.1f %.1f)",
+                    Math.min(wpIndex + 1, path.size()), path.size(), distToGoal,
+                    pos.x, pos.y, pos.z), false);
+            fail(mc);
+            return;
+        }
+
         // Check if we should stop early based on momentum
         if (shouldStopNow(mc, goal)) {
             beginDecelerate(mc);
@@ -225,7 +257,9 @@ public final class FlyExecutor {
 
         // -- Forward movement -----------------------------------------------
         applyStrafingMovement(mc, dx, dz);
-        ClientUtils.setKeyMappingState(mc.options.keySprint, distToGoal > 5.0);
+        // Generous no-sprint zone: sprint momentum near the goal is what causes
+        // multi-block overshoots.
+        ClientUtils.setKeyMappingState(mc.options.keySprint, distToGoal > 12.0);
         adjustVerticalKeysWithRaycast(mc, pos, dyWp);
 
         // -- Stuck detection ------------------------------------------------
@@ -242,9 +276,12 @@ public final class FlyExecutor {
         if (ticksSinceLastMove > TICKS_FOR_STUCK || stuckMs > STUCK_ABORT_MS) {
             if (stuckMs > STUCK_ABORT_MS) {
                 if (mc.player != null) {
-                    ClientUtils.sendMessage("\u00A7cFly stuck! Aborting navigation.", false);
+                    ClientUtils.sendMessage(String.format(
+                            "\u00A7cFly stuck! Aborting navigation. (wp %d/%d, dist %.1f, pos %.1f %.1f %.1f)",
+                            Math.min(wpIndex + 1, path.size()), path.size(), distToGoal,
+                            pos.x, pos.y, pos.z), false);
                 }
-                stop(mc);
+                fail(mc);
                 return;
             } else if (stuckMs > STUCK_CLIMB_MS) {
                 // Recovery: try climbing over the obstruction
@@ -256,8 +293,11 @@ public final class FlyExecutor {
         // Periodic debug output
         if (AetherConfig.SHOW_DEBUG.get()) {
             ClientUtils.sendDebugMessage(String.format(
-                    "fly wp=%d/%d dist=%.2f state=%s",
-                    Math.min(wpIndex + 1, path.size()), path.size(), distToGoal, state));
+                    "fly wp=%d/%d dist=%.2f best=%.2f noProg=%dms noMove=%dt state=%s",
+                    Math.min(wpIndex + 1, path.size()), path.size(), distToGoal,
+                    bestDistToGoal == Double.MAX_VALUE ? -1.0 : bestDistToGoal,
+                    System.currentTimeMillis() - lastGoalProgressTime,
+                    ticksSinceLastMove, state));
         }
     }
 
@@ -293,10 +333,30 @@ public final class FlyExecutor {
             return;
         }
         Vec3 vel = mc.player.getDeltaMovement();
-        boolean stopped = Math.abs(vel.x) < 0.05 && Math.abs(vel.z) < 0.05 && Math.abs(vel.y) < 0.05;
-        if (stopped || System.currentTimeMillis() - decelStartTime > 2000) {
-            finish(mc);
+        double horizSpeed = Math.sqrt(vel.x * vel.x + vel.z * vel.z);
+        // Actively brake instead of coasting: momentum from sprint flight can
+        // carry several blocks past the goal if we just release the keys.
+        // Airborne only - on the ground there's no glide to kill and holding S
+        // just walks us backwards off the spot.
+        boolean airborne = mc.player.getAbilities().flying && !mc.player.onGround();
+        ClientUtils.setKeyMappingState(mc.options.keyDown, airborne && horizSpeed > 0.08);
+        boolean stopped = horizSpeed < 0.05 && Math.abs(vel.y) < 0.05;
+        if (!stopped && System.currentTimeMillis() - decelStartTime <= 2000) {
+            return;
         }
+        ClientUtils.setKeyMappingState(mc.options.keyDown, false);
+
+        // If braking still left us short of (or past) the goal, resume flying
+        // to close the gap rather than finishing wherever momentum ran out.
+        Vec3 goal = new Vec3(goalX + 0.5, goalY + 0.15, goalZ + 0.5);
+        double dist = mc.player.position().distanceTo(goal);
+        if (dist > finalWaypointReach * 1.2 && decelResumes < 3 && path != null && !path.isEmpty()) {
+            decelResumes++;
+            wpIndex = path.size() - 1;
+            state = State.FLYING;
+            return;
+        }
+        finish(mc);
     }
 
     private void finish(Minecraft mc) {
@@ -306,6 +366,17 @@ public final class FlyExecutor {
         if (onFinished != null) {
             onFinished.run();
         }
+    }
+
+    /**
+     * Terminal failure. Unlike {@link #stop}, this leaves the executor in a
+     * distinct FAILED state so the manager can tell "gave up" apart from
+     * "reached goal" and hand off to recovery (unstuck + recompute).
+     */
+    private void fail(Minecraft mc) {
+        RotationExecutor.stopRotating();
+        releaseAll(mc);
+        state = State.FAILED;
     }
 
     /**
@@ -416,6 +487,15 @@ public final class FlyExecutor {
             // Something blocking at head level -> sneak down
             ClientUtils.setKeyMappingState(mc.options.keyShift, true);
             ClientUtils.setKeyMappingState(mc.options.keyJump, false);
+        } else if (blockAtFeet) {
+            // Wall taller than the player: climb over it, unless there's a
+            // ceiling right above us - then duck under instead of pinning on it.
+            HitResult upTrace = mc.level.clip(new ClipContext(headPos,
+                    headPos.add(0, RAY_DIST, 0),
+                    ClipContext.Block.COLLIDER, ClipContext.Fluid.NONE, mc.player));
+            boolean ceilingAbove = upTrace.getType() == HitResult.Type.BLOCK;
+            ClientUtils.setKeyMappingState(mc.options.keyJump, !ceilingAbove);
+            ClientUtils.setKeyMappingState(mc.options.keyShift, ceilingAbove);
         } else {
             // No obstruction - small Y correction if needed
             ClientUtils.setKeyMappingState(mc.options.keyJump, false);

--- a/src/main/java/dev/aether/modules/pest/helpers/PestDestroyer.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestDestroyer.java
@@ -997,6 +997,19 @@ public class PestDestroyer {
         if (!runtime.active) {
             return;
         }
+
+        // The roof climb leaves the camera craned nearly straight up; level it
+        // back out before moving off so the hand-off doesn't look robotic.
+        Minecraft levelClient = Minecraft.getInstance();
+        if (levelClient != null && levelClient.player != null) {
+            RotationManager.rotateToYawPitch(
+                    levelClient,
+                    levelClient.player.getYRot(),
+                    0f,
+                    AetherConfig.ROTATION_TIME.get(),
+                    true);
+        }
+
         if (returnState == null || returnState == State.IDLE || returnState == State.FINISH
                 || returnState == State.AOTV_TO_ROOF) {
             setState(runtime.vacuumSlot < 0 ? State.EQUIP_VACUUM : State.CHECK_NEXT);

--- a/src/main/java/dev/aether/modules/rewarp/RewarpManager.java
+++ b/src/main/java/dev/aether/modules/rewarp/RewarpManager.java
@@ -10,16 +10,24 @@ import dev.aether.macro.FarmingMacroManager;
 import dev.aether.macro.MacroState;
 import dev.aether.macro.MacroStateManager;
 import dev.aether.macro.MacroWorkerThread;
+import dev.aether.modules.failsafe.FailsafeManager;
 import dev.aether.modules.farming.SqueakyMousematManager;
 import dev.aether.modules.gear.GearManager;
 import dev.aether.modules.pathfinding.PathfindingManager;
+import dev.aether.modules.pathfinding.etherwarp.EtherwarpHelper;
+import dev.aether.modules.pathfinding.movement.WalkabilityChecker;
+import dev.aether.modules.pathfinding.wrapper.PathPosition;
 import dev.aether.modules.pest.PestManager;
 import dev.aether.modules.pest.helpers.PestReturnManager;
 import dev.aether.modules.rotation.RotationManager;
 import dev.aether.util.ClientUtils;
+import dev.aether.util.RotationUtils;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.ClipContext;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 
 import java.util.concurrent.CompletableFuture;
@@ -32,12 +40,44 @@ public final class RewarpManager {
     private static final long REWARP_FLY_STOP_MS = 0L;
     private static final long REWARP_POSITION_ADJUST_TIMEOUT_MS = 5000L;
     private static final long REWARP_POSITION_TAP_MS = 50L;
-    private static final long REWARP_POSITION_SETTLE_MS = 75L;
     private static final double REWARP_AOTV_ALIGN_XZ_TOLERANCE = 0.5;
 
+    // Fly-back recovery: how many times we recompute the path before giving up
+    // and forcing position with a command teleport.
+    private static final int REWARP_FLY_MAX_ATTEMPTS = 3;
+    // Hard wall-clock cap per fly attempt so a hung navigation can never freeze
+    // the worker thread (the original wait loop had no timeout).
+    private static final long REWARP_NAV_TIMEOUT_MS = 18000L;
+    private static final long REWARP_NAV_STARTUP_GRACE_MS = 2000L;
+    private static final long REWARP_UNSTUCK_MOVE_MS = 450L;
+    private static final long REWARP_UNSTUCK_CLIMB_STEP_MS = 350L;
+    private static final long REWARP_FALLBACK_SETTLE_MS = 600L;
+    // Small take-off hop so the fly path starts above the crops. Kept low and
+    // stall-aware so roofed farms don't get pinned against the ceiling.
+    private static final double REWARP_CLIMB_GAIN_BLOCKS = 3.0;
+    private static final long REWARP_CLIMB_TIMEOUT_MS = 3000L;
+    private static final long REWARP_CLIMB_STALL_MS = 400L;
+    private static final double REWARP_NEAR_START_ACCEPT_DIST = 3.0;
+    // Wider ring when AOTV align is on: the etherwarp covers the last stretch.
+    private static final double REWARP_NEAR_START_WARP_DIST = 8.0;
+    private static final int REWARP_MAX_SLOPPY_LANDINGS = 3;
+    private static final long REWARP_TAP_SETTLE_MAX_MS = 400L;
+    private static final long REWARP_SNEAK_PRIME_MS = 150L;
+    private static final long REWARP_WARP_SETTLE_TIMEOUT_MS = 900L;
+    private static final double REWARP_WARP_LAND_TOLERANCE = 1.5;
+    // Vertical tolerance against the exact captured start Y. A wall block next
+    // to the start is +1.0, so this must stay below that.
+    private static final double REWARP_START_Y_TOLERANCE = 0.75;
+
     private static long lastRewarpTime = 0;
+    // Rewarps in a row that ended away from the start point.
+    private static int consecutiveSloppyLandings = 0;
 
     private RewarpManager() {
+    }
+
+    private enum FlyNavResult {
+        ABORTED, REACHED, FAILED
     }
 
     public static void handle(Minecraft client) {
@@ -223,7 +263,13 @@ public final class RewarpManager {
     }
 
     private static boolean performCoordinateRewarp(Minecraft client, RewarpPointPair pair) {
+        ClientUtils.sendDebugMessage(String.format(
+                "[Rewarp] Fly-back begin: pair '%s', start (%.0f, %.0f, %.0f), player %s",
+                pair.displayName(), pair.startX, pair.startY, pair.startZ,
+                formatPos(getPlayerPosition(client))));
         ensureFlight(client);
+        ClientUtils.sendDebugMessage("[Rewarp] After ensureFlight: flying=" + isPlayerFlying(client)
+                + ", player " + formatPos(getPlayerPosition(client)));
         if (MacroWorkerThread.shouldAbortTask(client, MacroState.State.REWARPING)) {
             return false;
         }
@@ -233,20 +279,29 @@ public final class RewarpManager {
             return false;
         }
 
-        client.execute(() -> ClientUtils.setKeyMappingState(client.options.keyJump, true));
-        MacroWorkerThread.sleepRandom(1300, 300);
-        client.execute(() -> ClientUtils.setKeyMappingState(client.options.keyJump, false));
+        climbForTakeoff(client);
         if (MacroWorkerThread.shouldAbortTask(client, MacroState.State.REWARPING)) {
             return false;
         }
 
-        client.execute(() -> PathfindingManager.startFlyPathfind(
-                client,
-                (int) Math.floor(pair.startX),
-                87,
-                (int) Math.floor(pair.startZ)));
-        if (!waitForNavigationToFinish(client)) {
+        FlyNavResult flight = attemptFlyToStart(client, pair);
+        if (flight == FlyNavResult.ABORTED) {
             return false;
+        }
+        if (flight == FlyNavResult.FAILED) {
+            // Every fly attempt failed: force position with a command teleport,
+            // then give the fly one more bounded round from the fresh position.
+            ClientUtils.sendMessage("§cRewarp fly recovery failed, using teleport fallback.", false);
+            if (!performHardTpFallback(client, pair)) {
+                return false;
+            }
+            flight = attemptFlyToStart(client, pair);
+            if (flight == FlyNavResult.ABORTED) {
+                return false;
+            }
+            if (flight == FlyNavResult.FAILED) {
+                return stopMacroAfterRewarpFailure(client);
+            }
         }
 
         performAotvAlign(client, pair);
@@ -264,7 +319,7 @@ public final class RewarpManager {
             return false;
         }
 
-        return true;
+        return verifyRewarpLanding(client, pair);
     }
 
     private static void performAotvAlign(Minecraft client, RewarpPointPair pair) {
@@ -272,35 +327,181 @@ public final class RewarpManager {
             return;
         }
 
-        int aotvSlot = GearManager.findAspectOfTheVoidSlot(client);
-        if (aotvSlot < 0 || aotvSlot > 8) {
-            ClientUtils.sendDebugMessage("Rewarp align skipped: no AOTV/AOTE in hotbar");
+        double distance = distanceToStartXZ(client, pair);
+        if (!Double.isNaN(distance) && distance <= REWARP_WARP_LAND_TOLERANCE) {
+            // Close in XZ isn't enough: hovering over the edge of a wall block
+            // means the drop lands on the wall, a block above the start. Only
+            // skip the warp when the column below actually ends at start level.
+            double dropY = resolveDropLandingY(client);
+            if (!Double.isNaN(dropY) && Math.abs(dropY - pair.startY) <= REWARP_START_Y_TOLERANCE) {
+                ClientUtils.sendDebugMessage(String.format(
+                        "[Rewarp] Already %.1f blocks from start with clean drop, skipping warp.", distance));
+                return;
+            }
+            ClientUtils.sendDebugMessage(String.format(
+                    "[Rewarp] Drop here would land at y=%.1f (start y %.1f), warping instead.",
+                    dropY, pair.startY));
+        }
+
+        // Preferred: aim at the start block and etherwarp straight onto it, the
+        // same way the etherwarp pathfinder does. Falls back to the hover align
+        // when there's no Ether Transmission AOTV or no line of sight.
+        if (aimAndEtherwarpToStart(client, pair)) {
+            return;
+        }
+        if (MacroWorkerThread.shouldAbortTask(client, MacroState.State.REWARPING)) {
             return;
         }
 
+        // Fallback: shuffle until we're directly above the start, then let the
+        // unfly drop us onto it. No AOTV click here - it warps us off the spot.
         if (!stabilizeFlyPositionForAotv(client, pair)) {
             ClientUtils.sendDebugMessage("Rewarp align skipped: could not stabilize above target");
-            return;
+        }
+    }
+
+    private static boolean aimAndEtherwarpToStart(Minecraft client, RewarpPointPair pair) {
+        Integer slot = queryClientThread(client,
+                () -> GearManager.findEtherwarpAspectOfTheVoidHotbarSlot(client), -1);
+        if (slot == null || slot < 0) {
+            ClientUtils.sendDebugMessage("[Rewarp] No Ether Transmission AOTV in hotbar; using hover align.");
+            return false;
         }
 
-        rotateToRewarpStartBlock(client, pair);
-        if (MacroWorkerThread.shouldAbortTask(client, MacroState.State.REWARPING)) {
-            return;
-        }
+        PathPosition startCell = new PathPosition(
+                Math.floor(pair.startX), Math.floor(pair.startY), Math.floor(pair.startZ));
 
-        Vec3 playerPos = getPlayerPosition(client);
-        if (playerPos == null) {
-            return;
-        }
+        for (int attempt = 1; attempt <= 2; attempt++) {
+            if (MacroWorkerThread.shouldAbortTask(client, MacroState.State.REWARPING)) {
+                return false;
+            }
 
-        GearManager.swapToAOTVSync(client);
-        if (MacroWorkerThread.shouldAbortTask(client, MacroState.State.REWARPING)) {
-            return;
-        }
+            Vec3 aimPoint = queryClientThread(client, () -> {
+                if (client.player == null || client.level == null) {
+                    return null;
+                }
+                Vec3 eye = EtherwarpHelper.getEyePosition(client, client.player.position());
+                return EtherwarpHelper.findVisibleTargetPoint(
+                        client, new WalkabilityChecker(client.level), eye, startCell);
+            }, null);
+            if (aimPoint == null) {
+                ClientUtils.sendDebugMessage("[Rewarp] No line of sight to start block; using hover align.");
+                return false;
+            }
 
-        ClientUtils.performUseClick();
-        ClientUtils.waitForYChange(playerPos.y, 900);
-        MacroWorkerThread.sleepRandom(170, 60);
+            final int warpSlot = slot;
+            client.execute(() -> {
+                FailsafeManager.selectHotbarSlot(client, warpSlot);
+                ClientUtils.setKeyMappingState(client.options.keyShift, true);
+                if (client.player != null) {
+                    client.player.setShiftKeyDown(true);
+                }
+            });
+            // Let the sneak register server-side before the click, or the warp
+            // silently becomes an Instant Transmission.
+            MacroWorkerThread.sleep(REWARP_SNEAK_PRIME_MS);
+
+            Vec3 eyeNow = queryClientThread(client,
+                    () -> client.player == null
+                            ? null
+                            : EtherwarpHelper.getEyePosition(client, client.player.position()),
+                    null);
+            if (eyeNow == null) {
+                releaseSneakKeys(client);
+                return false;
+            }
+            RotationUtils.Rotation look = RotationUtils.calculateLookAt(eyeNow, aimPoint);
+            client.execute(() -> RotationManager.rotateToYawPitch(
+                    client, look.yaw, look.pitch, AetherConfig.ROTATION_TIME.get(), true));
+            while (RotationManager.isRotating()) {
+                if (MacroWorkerThread.shouldAbortTask(client, MacroState.State.REWARPING)) {
+                    releaseSneakKeys(client);
+                    return false;
+                }
+                MacroWorkerThread.sleep(25);
+            }
+
+            // Re-check the aim right before firing: any drift between the aim
+            // computation and now would send the warp somewhere else entirely.
+            final Vec3 verifyPoint = aimPoint;
+            boolean aimed = Boolean.TRUE.equals(queryClientThread(client, () -> {
+                if (client.player == null) {
+                    return false;
+                }
+                Vec3 eye = EtherwarpHelper.getEyePosition(client, client.player.position());
+                return RotationUtils.isLookingAt(
+                        client.player.getYRot(), client.player.getXRot(), eye, verifyPoint, 2.0f);
+            }, false));
+            if (!aimed) {
+                releaseSneakKeys(client);
+                ClientUtils.sendDebugMessage("[Rewarp] Warp aim drifted, retrying.");
+                continue;
+            }
+
+            Vec3 prePos = getPlayerPosition(client);
+            client.execute(ClientUtils::performUseClick);
+            boolean moved = waitForWarpSettle(client, prePos);
+            releaseSneakKeys(client);
+
+            double distance = distanceToStartXZ(client, pair);
+            Vec3 postPos = getPlayerPosition(client);
+            double dy = postPos == null ? Double.NaN : postPos.y - pair.startY;
+            ClientUtils.sendDebugMessage(String.format(
+                    "[Rewarp] Etherwarp align attempt %d: moved=%s, %.1f blocks from start, dy=%.1f",
+                    attempt, moved, distance, dy));
+            if (!Double.isNaN(distance) && distance <= REWARP_WARP_LAND_TOLERANCE
+                    && !Double.isNaN(dy) && Math.abs(dy) <= REWARP_START_Y_TOLERANCE) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** Feet Y where a straight-down drop from the current position would land. */
+    private static double resolveDropLandingY(Minecraft client) {
+        Double landingY = queryClientThread(client, () -> {
+            if (client.player == null || client.level == null) {
+                return null;
+            }
+            Vec3 from = client.player.position();
+            BlockHitResult hit = client.level.clip(new ClipContext(
+                    from,
+                    from.add(0, -32, 0),
+                    ClipContext.Block.COLLIDER,
+                    ClipContext.Fluid.NONE,
+                    client.player));
+            if (hit.getType() != HitResult.Type.BLOCK) {
+                return null;
+            }
+            return hit.getLocation().y;
+        }, null);
+        return landingY == null ? Double.NaN : landingY;
+    }
+
+    private static boolean waitForWarpSettle(Minecraft client, Vec3 prePos) {
+        if (prePos == null) {
+            MacroWorkerThread.sleep(REWARP_WARP_SETTLE_TIMEOUT_MS);
+            return false;
+        }
+        long deadline = System.currentTimeMillis() + REWARP_WARP_SETTLE_TIMEOUT_MS;
+        while (System.currentTimeMillis() < deadline) {
+            Vec3 pos = getPlayerPosition(client);
+            if (pos != null && pos.distanceTo(prePos) > 1.0) {
+                MacroWorkerThread.sleepRandom(120, 60);
+                return true;
+            }
+            MacroWorkerThread.sleep(50);
+        }
+        return false;
+    }
+
+    private static void releaseSneakKeys(Minecraft client) {
+        client.execute(() -> {
+            ClientUtils.setKeyMappingState(client.options.keyShift, false);
+            if (client.player != null) {
+                client.player.setShiftKeyDown(false);
+            }
+        });
     }
 
     private static boolean stabilizeFlyPositionForAotv(Minecraft client, RewarpPointPair pair) {
@@ -315,7 +516,8 @@ public final class RewarpManager {
             return false;
         }
 
-        long deadline = System.currentTimeMillis() + REWARP_POSITION_ADJUST_TIMEOUT_MS;
+        long startedAt = System.currentTimeMillis();
+        long deadline = startedAt + REWARP_POSITION_ADJUST_TIMEOUT_MS;
         while (System.currentTimeMillis() < deadline) {
             if (MacroWorkerThread.shouldAbortTask(client, MacroState.State.REWARPING)) {
                 return false;
@@ -332,6 +534,9 @@ public final class RewarpManager {
             if (Math.abs(deltaX) <= REWARP_AOTV_ALIGN_XZ_TOLERANCE
                     && Math.abs(deltaZ) <= REWARP_AOTV_ALIGN_XZ_TOLERANCE) {
                 releaseHorizontalMovementKeys(client);
+                ClientUtils.sendDebugMessage(String.format(
+                        "[Rewarp] AOTV stabilize ok in %d ms (dx=%.2f dz=%.2f)",
+                        System.currentTimeMillis() - startedAt, deltaX, deltaZ));
                 return true;
             }
 
@@ -352,19 +557,273 @@ public final class RewarpManager {
         }
 
         releaseHorizontalMovementKeys(client);
+        Vec3 endPos = getPlayerPosition(client);
+        if (endPos != null) {
+            Vec3 targetPos = getRewarpWalkGoalPosition(pair);
+            ClientUtils.sendDebugMessage(String.format(
+                    "[Rewarp] AOTV stabilize timed out, offset dx=%.2f dz=%.2f",
+                    targetPos.x - endPos.x, targetPos.z - endPos.z));
+        }
         return false;
     }
 
-    private static boolean waitForNavigationToFinish(Minecraft client) {
-        MacroWorkerThread.sleepRandom(170, 60);
+    private static FlyNavResult attemptFlyToStart(Minecraft client, RewarpPointPair pair) {
+        for (int attempt = 1; attempt <= REWARP_FLY_MAX_ATTEMPTS; attempt++) {
+            ClientUtils.sendDebugMessage(String.format(
+                    "[Rewarp] Fly attempt %d/%d to (%d, %d, %d) from %s",
+                    attempt, REWARP_FLY_MAX_ATTEMPTS,
+                    (int) Math.floor(pair.startX), (int) Math.floor(pair.startY) + 1,
+                    (int) Math.floor(pair.startZ), formatPos(getPlayerPosition(client))));
+            // Target one block above the real start point: the 3D pathfinder still
+            // routes under roofs and around walls, but hovering keeps us off the
+            // floor - touching down kicks us out of flight mid-approach.
+            client.execute(() -> PathfindingManager.startFlyPathfind(
+                    client,
+                    (int) Math.floor(pair.startX),
+                    (int) Math.floor(pair.startY) + 1,
+                    (int) Math.floor(pair.startZ)));
+
+            FlyNavResult result = awaitFlyNavigation(client);
+            ClientUtils.sendDebugMessage(String.format(
+                    "[Rewarp] Fly attempt %d result: %s, player %s, %.1f blocks from start",
+                    attempt, result, formatPos(getPlayerPosition(client)),
+                    distanceToStartXZ(client, pair)));
+            if (result == FlyNavResult.ABORTED || result == FlyNavResult.REACHED) {
+                return result;
+            }
+
+            // A failed fly that still got us next to the start is good enough;
+            // the AOTV align / unfly handles the last couple of blocks.
+            if (isNearRewarpStartXZ(client, pair)) {
+                ClientUtils.sendMessage("§eRewarp fly stopped close to the start point, continuing.", false);
+                return FlyNavResult.REACHED;
+            }
+
+            if (attempt < REWARP_FLY_MAX_ATTEMPTS) {
+                ClientUtils.sendMessage("§eRewarp fly stuck (try " + attempt + "/"
+                        + REWARP_FLY_MAX_ATTEMPTS + "), unsticking and recomputing.", false);
+                performUnstuckNudge(client, attempt);
+                if (MacroWorkerThread.shouldAbortTask(client, MacroState.State.REWARPING)) {
+                    return FlyNavResult.ABORTED;
+                }
+            }
+        }
+        return FlyNavResult.FAILED;
+    }
+
+    private static FlyNavResult awaitFlyNavigation(Minecraft client) {
+        // The pathfind start is queued on the client thread; wait for it to land
+        // so a slow frame can't make us misread "not navigating" as a finished run.
+        long startupDeadline = System.currentTimeMillis() + REWARP_NAV_STARTUP_GRACE_MS;
+        while (!PathfindingManager.isNavigating() && System.currentTimeMillis() < startupDeadline) {
+            if (MacroWorkerThread.shouldAbortTask(client, MacroState.State.REWARPING)) {
+                return FlyNavResult.ABORTED;
+            }
+            MacroWorkerThread.sleep(50);
+        }
+        if (!PathfindingManager.isNavigating()) {
+            ClientUtils.sendDebugMessage("[Rewarp] Fly navigation never started (or ended instantly).");
+        }
+
+        long deadline = System.currentTimeMillis() + REWARP_NAV_TIMEOUT_MS;
         while (PathfindingManager.isNavigating()) {
             if (MacroWorkerThread.shouldAbortTask(client, MacroState.State.REWARPING)) {
-                PathfindingManager.stop();
-                return false;
+                PathfindingManager.stop(false);
+                return FlyNavResult.ABORTED;
+            }
+            if (System.currentTimeMillis() > deadline) {
+                // Hard cap: treat a hung navigation as a failed attempt to recover from.
+                PathfindingManager.stop(false);
+                ClientUtils.sendMessage("§cRewarp fly attempt timed out.", false);
+                return FlyNavResult.FAILED;
             }
             MacroWorkerThread.sleep(100);
         }
-        return MacroStateManager.getCurrentState() == MacroState.State.REWARPING;
+        if (MacroStateManager.getCurrentState() != MacroState.State.REWARPING) {
+            return FlyNavResult.ABORTED;
+        }
+        return PathfindingManager.lastFlyReachedGoal() ? FlyNavResult.REACHED : FlyNavResult.FAILED;
+    }
+
+    private static void climbForTakeoff(Minecraft client) {
+        Vec3 startPos = getPlayerPosition(client);
+        if (startPos == null) {
+            return;
+        }
+
+        client.execute(() -> ClientUtils.setKeyMappingState(client.options.keyJump, true));
+        long deadline = System.currentTimeMillis() + REWARP_CLIMB_TIMEOUT_MS;
+        double lastY = startPos.y;
+        long lastGainAt = System.currentTimeMillis();
+        String exitReason = "timeout";
+        while (System.currentTimeMillis() < deadline) {
+            if (MacroWorkerThread.shouldAbortTask(client, MacroState.State.REWARPING)) {
+                exitReason = "aborted";
+                break;
+            }
+            Vec3 pos = getPlayerPosition(client);
+            if (pos == null || pos.y - startPos.y >= REWARP_CLIMB_GAIN_BLOCKS) {
+                exitReason = "gained height";
+                break;
+            }
+            if (pos.y > lastY + 0.05) {
+                lastY = pos.y;
+                lastGainAt = System.currentTimeMillis();
+            } else if (System.currentTimeMillis() - lastGainAt > REWARP_CLIMB_STALL_MS) {
+                // Ceiling overhead: stop pushing into it and let the pathfinder
+                // work from here.
+                exitReason = "ceiling";
+                break;
+            }
+            MacroWorkerThread.sleep(50);
+        }
+        client.execute(() -> ClientUtils.setKeyMappingState(client.options.keyJump, false));
+        ClientUtils.sendDebugMessage(String.format("[Rewarp] Takeoff climb done (%s): y %.1f -> %s",
+                exitReason, startPos.y, formatPos(getPlayerPosition(client))));
+    }
+
+    private static void performUnstuckNudge(Minecraft client, int attempt) {
+        PathfindingManager.stop(false);
+        releaseHorizontalMovementKeys(client);
+        // Back out sideways to leave the pocket we got wedged in. Alternate the
+        // strafe side and the vertical direction each retry so repeats don't
+        // loop: up can pin against a roof, down can pin on crops, so try both.
+        KeyMapping strafeKey = attempt % 2 == 0 ? client.options.keyLeft : client.options.keyRight;
+        KeyMapping verticalKey = attempt % 2 == 0 ? client.options.keyShift : client.options.keyJump;
+        ClientUtils.sendDebugMessage("[Rewarp] Unstuck nudge " + attempt + ": back+"
+                + (attempt % 2 == 0 ? "left+down" : "right+up"));
+        client.execute(() -> {
+            ClientUtils.setKeyMappingState(client.options.keyDown, true);
+            ClientUtils.setKeyMappingState(strafeKey, true);
+            ClientUtils.setKeyMappingState(verticalKey, true);
+        });
+        MacroWorkerThread.sleep(REWARP_UNSTUCK_MOVE_MS);
+        client.execute(() -> {
+            ClientUtils.setKeyMappingState(client.options.keyDown, false);
+            ClientUtils.setKeyMappingState(strafeKey, false);
+        });
+        MacroWorkerThread.sleep(REWARP_UNSTUCK_CLIMB_STEP_MS * attempt);
+        client.execute(() -> ClientUtils.setKeyMappingState(verticalKey, false));
+        MacroWorkerThread.sleepRandom(150, 50);
+    }
+
+    private static boolean performHardTpFallback(Minecraft client, RewarpPointPair pair) {
+        if (client == null || client.player == null) {
+            return false;
+        }
+
+        PathfindingManager.stop(false);
+        releaseHorizontalMovementKeys(client);
+
+        // FLY pairs don't carry a command, so pick a teleport that will resolve:
+        // the configured plot if one is set, otherwise /warp garden.
+        RewarpMode fallbackMode = hasUsablePlotNumber(pair) ? RewarpMode.PLOT_TP : RewarpMode.WARP_GARDEN;
+        ClientUtils.sendDebugMessage("[Rewarp] TP fallback via " + fallbackMode.displayName());
+        client.execute(() -> {
+            ConfigHelpers.executeRewarpCommand(fallbackMode, pair.plotTpNumber);
+            AbstractMacro active = FarmingMacroManager.getActiveMacro();
+            if (active != null) {
+                active.suppressDropDetection(3000);
+            }
+        });
+        MacroWorkerThread.sleep(REWARP_FALLBACK_SETTLE_MS);
+        if (MacroWorkerThread.shouldAbortTask(client, MacroState.State.REWARPING)) {
+            return false;
+        }
+
+        // The teleport may have dropped us out of flight; get airborne again for
+        // the follow-up fly attempt.
+        ensureFlight(client);
+        if (MacroWorkerThread.shouldAbortTask(client, MacroState.State.REWARPING)) {
+            return false;
+        }
+        climbForTakeoff(client);
+        return !MacroWorkerThread.shouldAbortTask(client, MacroState.State.REWARPING);
+    }
+
+    private static boolean isNearRewarpStartXZ(Minecraft client, RewarpPointPair pair) {
+        double distance = distanceToStartXZ(client, pair);
+        // With AOTV align on, the etherwarp can cover the last few blocks, so a
+        // slightly overshot fly still counts as arrived.
+        double acceptDist = pair.aotvAlign ? REWARP_NEAR_START_WARP_DIST : REWARP_NEAR_START_ACCEPT_DIST;
+        return !Double.isNaN(distance) && distance <= acceptDist;
+    }
+
+    private static double distanceToStartXZ(Minecraft client, RewarpPointPair pair) {
+        Vec3 pos = getPlayerPosition(client);
+        if (pos == null) {
+            return Double.NaN;
+        }
+        double dx = pos.x - (Math.floor(pair.startX) + 0.5);
+        double dz = pos.z - (Math.floor(pair.startZ) + 0.5);
+        return Math.sqrt(dx * dx + dz * dz);
+    }
+
+    private static String formatPos(Vec3 pos) {
+        return pos == null
+                ? "(unknown)"
+                : String.format("(%.1f, %.1f, %.1f)", pos.x, pos.y, pos.z);
+    }
+
+    private static boolean verifyRewarpLanding(Minecraft client, RewarpPointPair pair) {
+        if (!isLandedOnStart(client, pair) && pair.aotvAlign) {
+            // Typical miss: dropped onto the wall block beside the start. Re-aim
+            // at the block centre and etherwarp down onto it.
+            ClientUtils.sendDebugMessage("[Rewarp] Landed off the start point, correcting with etherwarp.");
+            aimAndEtherwarpToStart(client, pair);
+        }
+
+        Vec3 landed = getPlayerPosition(client);
+        if (landed == null) {
+            return true;
+        }
+        double distance = distanceToStartXZ(client, pair);
+        double dy = landed.y - pair.startY;
+        if (isLandedOnStart(client, pair)) {
+            consecutiveSloppyLandings = 0;
+            ClientUtils.sendDebugMessage(String.format(
+                    "[Rewarp] Landed %.1f blocks from start (dy=%.1f).", distance, dy));
+            return true;
+        }
+
+        // Landing repeatedly away from the start means every rewarp drifts and
+        // re-triggers; stop instead of ping-ponging across the farm all night.
+        consecutiveSloppyLandings++;
+        ClientUtils.sendMessage(String.format(
+                "§eRewarp landed %.1f blocks from the start point, dy=%.1f (%d/%d tolerated).",
+                distance, dy, consecutiveSloppyLandings, REWARP_MAX_SLOPPY_LANDINGS), false);
+        if (consecutiveSloppyLandings >= REWARP_MAX_SLOPPY_LANDINGS) {
+            consecutiveSloppyLandings = 0;
+            return stopMacroAfterRewarpFailure(client);
+        }
+        return true;
+    }
+
+    private static boolean isLandedOnStart(Minecraft client, RewarpPointPair pair) {
+        Vec3 pos = getPlayerPosition(client);
+        if (pos == null) {
+            return false;
+        }
+        double distance = distanceToStartXZ(client, pair);
+        double dy = pos.y - pair.startY;
+        return !Double.isNaN(distance)
+                && distance <= REWARP_NEAR_START_ACCEPT_DIST
+                && Math.abs(dy) <= REWARP_START_Y_TOLERANCE;
+    }
+
+    private static boolean stopMacroAfterRewarpFailure(Minecraft client) {
+        PathfindingManager.stop(false);
+        releaseHorizontalMovementKeys(client);
+        ClientUtils.sendMessage("§cRewarp could not reach the start point. Stopping the macro for safety.", false);
+        MacroStateManager.setCurrentState(MacroState.State.OFF);
+        return false;
+    }
+
+    private static boolean hasUsablePlotNumber(RewarpPointPair pair) {
+        // "0" is the config default for FLY pairs, so treat it as "not configured".
+        return pair.plotTpNumber != null
+                && !pair.plotTpNumber.isBlank()
+                && !pair.plotTpNumber.trim().equals("0");
     }
 
     private static void ensureFlight(Minecraft client) {
@@ -439,7 +898,19 @@ public final class RewarpManager {
         client.execute(() -> ClientUtils.setKeyMappingState(key, true));
         MacroWorkerThread.sleep(REWARP_POSITION_TAP_MS);
         client.execute(() -> ClientUtils.setKeyMappingState(key, false));
-        MacroWorkerThread.sleep(REWARP_POSITION_SETTLE_MS);
+
+        // Wait for the flight glide to die down before measuring again. A fixed
+        // short settle let each tap coast past the target, which caused the
+        // visible back-and-forth wobble above the rewarp point.
+        long settleDeadline = System.currentTimeMillis() + REWARP_TAP_SETTLE_MAX_MS;
+        while (System.currentTimeMillis() < settleDeadline) {
+            MacroWorkerThread.sleep(40);
+            Vec3 velocity = getPlayerVelocity(client);
+            if (velocity == null
+                    || (Math.abs(velocity.x) < 0.03 && Math.abs(velocity.z) < 0.03)) {
+                break;
+            }
+        }
     }
 
     private static void releaseHorizontalMovementKeys(Minecraft client) {
@@ -467,6 +938,12 @@ public final class RewarpManager {
     private static Vec3 getPlayerPosition(Minecraft client) {
         return queryClientThread(client,
                 () -> client.player == null ? null : client.player.position(),
+                null);
+    }
+
+    private static Vec3 getPlayerVelocity(Minecraft client) {
+        return queryClientThread(client,
+                () -> client.player == null ? null : client.player.getDeltaMovement(),
                 null);
     }
 


### PR DESCRIPTION
## Summary
- Fly rewarp now targets the actual start point (one block above the floor) so the 3D pathfinder routes under and around farm roofs and walls, instead of flying to a hard-coded Y=87 and stranding on top of structures
- FlyExecutor gains real stall detection (net distance-to-goal progress, not just per-tick movement), a FAILED state that propagates instead of hanging navigation, active braking during deceleration to stop sprint-momentum overshoots, resume-if-short corrections, and roof-aware vertical obstacle handling
- RewarpManager recovery chain: bounded retries with an alternating unstuck nudge, a navigation wall-clock timeout (the old wait loop could hang forever), a plot-TP/warp-garden fallback, and a safe macro stop if everything fails
- Arrival is now exact: the drop is only taken when the column below actually ends at start level, otherwise it aims at the start block centre and etherwarps onto it (same mechanics as the etherwarp pathfinder, with sneak priming and pre-click aim verification); landings are verified in XZ and Y with an etherwarp correction for wall-top misses
- Roof-climb AOTV in the pest destroyer levels the camera before moving toward pests
- Debug logging across the whole rewarp pipeline (attempts, results, distances, dy) behind Show Debug

## Testing
- Verified in-game on a roofed farm: fly-back routes under the roof, brakes without overshooting, and lands on the exact start block; wall-top landings are corrected via etherwarp
- Recovery chain exercised in-game (stalled attempts, TP fallback, re-fly) via debug logs