### PR TITLE
fix: pest roof-AOTV freeze and camera level-out

### DIFF
--- a/src/main/java/dev/aether/modules/pest/helpers/PestDestroyer.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestDestroyer.java
@@ -310,6 +310,28 @@ public class PestDestroyer {
         if (!runtime.active) {
             return;
         }
+
+        // The roof climb leaves the camera craned nearly straight up; level it
+        // back out before moving off so the hand-off doesn't look robotic.
+        // Strictly cosmetic and guarded: this method is the ONLY way out of
+        // AOTV_TO_ROOF and some callers swallow throwables, so nothing here may
+        // ever prevent the state transition below (a swallowed throw silently
+        // froze the destroyer in AOTV_TO_ROOF).
+        try {
+            Minecraft levelClient = Minecraft.getInstance();
+            if (levelClient != null && levelClient.player != null
+                    && levelClient.player.getXRot() < -30f) {
+                RotationManager.rotateToYawPitch(
+                        levelClient,
+                        levelClient.player.getYRot(),
+                        0f,
+                        AetherConfig.ROTATION_TIME.get(),
+                        true);
+            }
+        } catch (Throwable t) {
+            ClientUtils.sendDebugMessage("[PestDestroyer] Camera level-out failed: " + t);
+        }
+
         if (returnState == null || returnState == State.IDLE || returnState == State.FINISH
                 || returnState == State.AOTV_TO_ROOF) {
             setState(runtime.vacuumSlot < 0 ? State.EQUIP_VACUUM : State.CHECK_NEXT);


### PR DESCRIPTION
## Summary
- **Freeze fix**: `completeRoofAotv()` is the only way out of the `AOTV_TO_ROOF` state, and some callers wrap it in `catch (Throwable)`. The camera level-out added for the hand-off could throw and get swallowed, silently stalling the pest destroyer (seen when a plot had open sky above the landing spot). The level-out is now isolated in its own guarded block so it can never prevent the state transition, and logs the error if it ever fires.
- **Camera level-out**: after the roof AOTV climb the camera is craned ~88° up to warp through the roof and never reset. It's now smoothly returned to horizontal before the bot moves toward pests, and only runs when the pitch is actually steep.

## Testing
Verified in-game: a plot with no roof no longer freezes the destroyer, and the camera levels out after the roof climb instead of moving off craned upward.