### PR TITLE
fix: aether is now loadable on lunar's fabric

### DIFF
--- a/src/main/java/dev/aether/mixin/MixinEntityTurn.java
+++ b/src/main/java/dev/aether/mixin/MixinEntityTurn.java
@@ -1,0 +1,27 @@
+package dev.aether.mixin;
+
+import dev.aether.bootstrap.AetherBootstrapHooks;
+import net.minecraft.client.Minecraft;
+import net.minecraft.world.entity.Entity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(Entity.class)
+public abstract class MixinEntityTurn {
+    // lunar fabric redirects turnPlayer's #turn invocation so we inject a layer
+    // deeper to prevent lunar from complaining that its gone
+    @Inject(method = "turn", at = @At("HEAD"), cancellable = true)
+    private void aether$routeLocalPlayerTurn(double yRot, double xRot, CallbackInfo ci) {
+        Minecraft client = Minecraft.getInstance();
+        if ((Object) this != client.player) {
+            return;
+        }
+        if (AetherBootstrapHooks.turnFreecamCamera(yRot, xRot) // verbatim
+         || AetherBootstrapHooks.turnFreelookCamera(yRot, xRot)
+        ) {
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/java/dev/aether/mixin/MixinKeyboardInput.java
+++ b/src/main/java/dev/aether/mixin/MixinKeyboardInput.java
@@ -10,6 +10,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.Unique;
 
 @Mixin(KeyboardInput.class)
 public abstract class MixinKeyboardInput extends ClientInput {
@@ -65,10 +66,15 @@ public abstract class MixinKeyboardInput extends ClientInput {
             shift,
             sprint
         );
-        this.moveVector = new Vec2(calculateImpulse(left, right), calculateImpulse(forward, backward)).normalized();
+        this.moveVector = new Vec2(
+            aetherModCalculateImpulse(left, right), 
+            aetherModCalculateImpulse(forward, backward)
+        ).normalized();
     }
-
-    private static float calculateImpulse(boolean positive, boolean negative) {
+    
+    @Unique // lunar turned this method vis to PUBLIC for some reason
+    // this makes sure it doesn't overshadow lunar decision
+    private static float aetherModCalculateImpulse(boolean positive, boolean negative) {
         if (positive == negative) {
             return 0.0f;
         }

--- a/src/main/java/dev/aether/mixin/MixinMouseHandler.java
+++ b/src/main/java/dev/aether/mixin/MixinMouseHandler.java
@@ -5,11 +5,9 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.MouseHandler;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.input.MouseButtonInfo;
-import net.minecraft.client.player.LocalPlayer;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(MouseHandler.class)
@@ -19,23 +17,6 @@ public class MixinMouseHandler {
         if (AetherBootstrapHooks.shouldCancelMouseTurn()) {
             ci.cancel();
         }
-    }
-
-    @Redirect(
-        method = "turnPlayer",
-        at = @At(
-            value = "INVOKE",
-            target = "Lnet/minecraft/client/player/LocalPlayer;turn(DD)V"
-        )
-    )
-    private void redirectTurnPlayer(LocalPlayer player, double yRot, double xRot) {
-        if (AetherBootstrapHooks.turnFreecamCamera(yRot, xRot)) {
-            return;
-        }
-        if (AetherBootstrapHooks.turnFreelookCamera(yRot, xRot)) {
-            return;
-        }
-        player.turn(yRot, xRot);
     }
 
     /** Block vanilla from re-grabbing the cursor while the macro has released it. */

--- a/src/main/resources/aether.mixins.json
+++ b/src/main/resources/aether.mixins.json
@@ -15,6 +15,7 @@
         "AccessorScreen",
         "AccessorWindow",
         "PlayerTabOverlayAccessor",
+        "MixinEntityTurn",
         "MixinPlayer",
         "MixinPlayerInfo",
         "MixinPlayerTeam",


### PR DESCRIPTION
This fixes Aether on Lunar Client's Fabric by patching some mixins compatibility problems
- inject one level deeper into turn in Entity because Lunar redirects turnPlayer's turn
- changed signature of calculateImpulse to avoid shadowing lunar decision to make it PUBLIC for some reason
