### PR TITLE
more bug fixes

### DIFF
--- a/src/main/java/dev/aether/config/AetherConfig.java
+++ b/src/main/java/dev/aether/config/AetherConfig.java
@@ -340,12 +340,10 @@ public final class AetherConfig {
         private static boolean migrateLegacyLoadoutKeys(JsonObject root) {
                 boolean updated = false;
 
-                if (!root.has("autoLoadoutPest") && root.has("autoWardrobePest")) {
-                        AUTO_LOADOUT_PEST.set(readBoolean(root, "autoWardrobePest", AUTO_LOADOUT_PEST.get()));
-                        updated = true;
-                }
-                if (!root.has("autoLoadoutVisitor") && root.has("autoWardrobeVisitor")) {
-                        AUTO_LOADOUT_VISITOR.set(readBoolean(root, "autoWardrobeVisitor", AUTO_LOADOUT_VISITOR.get()));
+                // Loadout swapping is determined solely by the configured slots. Remove
+                // retired enable flags when rewriting legacy configs.
+                if (root.has("autoLoadoutPest") || root.has("autoLoadoutVisitor")
+                                || root.has("autoWardrobePest") || root.has("autoWardrobeVisitor")) {
                         updated = true;
                 }
                 if (!root.has("loadoutSlotFarming") && root.has("wardrobeSlotFarming")) {
@@ -524,8 +522,6 @@ public final class AetherConfig {
 
         // -- AUTO LOADOUT ----------------------------------------------------------
 
-        public static final BooleanEntry AUTO_LOADOUT_PEST = Config.bool("autoLoadoutPest", false);
-        public static final BooleanEntry AUTO_LOADOUT_VISITOR = Config.bool("autoLoadoutVisitor", false);
         public static final IntEntry LOADOUT_SLOT_FARMING = Config.integer("loadoutSlotFarming", 1).range(1, 12);
         public static final IntEntry LOADOUT_SLOT_PEST = Config.integer("loadoutSlotPest", 2).range(1, 12);
         public static final IntEntry LOADOUT_SLOT_PEST_KILL = Config.integer("loadoutSlotPestKill", 1).range(1, 12);

--- a/src/main/java/dev/aether/modules/pest/ManualPestManager.java
+++ b/src/main/java/dev/aether/modules/pest/ManualPestManager.java
@@ -9,6 +9,7 @@ import dev.aether.modules.failsafe.FailsafeColourFlashManager;
 import dev.aether.modules.failsafe.FailsafeSoundManager;
 import dev.aether.modules.gear.GearManager;
 import dev.aether.modules.gear.helpers.LoadoutManager;
+import dev.aether.modules.pest.helpers.PestCompletionGuard;
 import dev.aether.util.ClientUtils;
 import dev.aether.util.CommandUtils;
 import dev.aether.util.WindowFocusHelper;
@@ -25,6 +26,8 @@ public final class ManualPestManager {
 
     private static volatile Phase phase = Phase.IDLE;
     private static volatile int pausedFromLoadout = -1;
+    private static volatile long waitingStartedAt = 0L;
+    private static volatile int clearedPestTabTicks = 0;
 
     private ManualPestManager() {
     }
@@ -32,6 +35,8 @@ public final class ManualPestManager {
     public static void reset() {
         phase = Phase.IDLE;
         pausedFromLoadout = -1;
+        waitingStartedAt = 0L;
+        clearedPestTabTicks = 0;
         PestManager.clearCleaningTriggerPending();
     }
 
@@ -78,7 +83,20 @@ public final class ManualPestManager {
         }
 
         if (currentPestCount(client) <= 0) {
-            beginResume(client);
+            if (!PestCompletionGuard.shouldAcceptFinishReading(waitingStartedAt, false)) {
+                if (clearedPestTabTicks == 0) {
+                    ClientUtils.sendDebugMessage("Manual pest: ignoring clear tab reading during startup grace.");
+                }
+                clearedPestTabTicks = 0;
+                return;
+            }
+
+            clearedPestTabTicks++;
+            if (PestCompletionGuard.isConfirmed(clearedPestTabTicks)) {
+                beginResume(client);
+            }
+        } else {
+            clearedPestTabTicks = 0;
         }
     }
 
@@ -95,6 +113,8 @@ public final class ManualPestManager {
             client.execute(() -> {
                 if (phase == Phase.PREPARING && AetherConfig.MANUAL_PEST_MODE.get()) {
                     phase = Phase.WAITING;
+                    waitingStartedAt = System.currentTimeMillis();
+                    clearedPestTabTicks = 0;
                     fireAlert(count);
                 }
             });
@@ -116,6 +136,8 @@ public final class ManualPestManager {
                     }
                     PestManager.clearCleaningTriggerPending();
                     phase = Phase.IDLE;
+                    waitingStartedAt = 0L;
+                    clearedPestTabTicks = 0;
                 });
             }
         });

--- a/src/main/java/dev/aether/modules/pest/ManualPestManager.java
+++ b/src/main/java/dev/aether/modules/pest/ManualPestManager.java
@@ -144,10 +144,6 @@ public final class ManualPestManager {
     }
 
     private static void swapToPestKillLoadout(Minecraft client, int previousLoadout) {
-        if (!AetherConfig.AUTO_LOADOUT_PEST.get()) {
-            return;
-        }
-
         int targetSlot = AetherConfig.LOADOUT_SLOT_PEST_KILL.get();
         if (targetSlot <= 0) {
             return;
@@ -163,10 +159,6 @@ public final class ManualPestManager {
     }
 
     private static void restoreFarmingLoadout(Minecraft client) {
-        if (!AetherConfig.AUTO_LOADOUT_PEST.get()) {
-            return;
-        }
-
         int targetSlot = AetherConfig.LOADOUT_SLOT_FARMING.get();
         if (targetSlot <= 0) {
             return;

--- a/src/main/java/dev/aether/modules/pest/helpers/PestCombatCoordinator.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestCombatCoordinator.java
@@ -389,6 +389,7 @@ final class PestCombatCoordinator {
             ClientUtils.sendDebugMessage("[PestDestroyer] Using AOTV (" + (context.getAotvUseCount() + 1) + "). Distance: "
                             + String.format("%.1f", dist));
             ClientUtils.performUseClick();
+            FailsafeManager.addRotationGracePeriod(AOTV_POST_CLICK_GRACE_MS);
             context.setAotvPostClickGraceUntil(now + AOTV_POST_CLICK_GRACE_MS);
             context.setAotvLastUsePlayerX(client.player.getX());
             context.setAotvLastUsePlayerY(client.player.getY());

--- a/src/main/java/dev/aether/modules/pest/helpers/PestCompletionGuard.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestCompletionGuard.java
@@ -1,0 +1,31 @@
+package dev.aether.modules.pest.helpers;
+
+/**
+ * Shared guard for pest completion decisions that are driven by tab-list data.
+ * The tab list can lag immediately after a pest spawn/cleaning handoff, so
+ * callers should ignore finish-level readings during startup and then require
+ * consecutive confirmations before treating pests as cleared.
+ */
+public final class PestCompletionGuard {
+    public static final long STARTUP_FINISH_GRACE_MS = 5_000L;
+    public static final int TAB_FINISH_CONFIRM_TICKS = 10;
+
+    private PestCompletionGuard() {
+    }
+
+    public static boolean isInStartupGrace(long activatedAtMs) {
+        return System.currentTimeMillis() - activatedAtMs < STARTUP_FINISH_GRACE_MS;
+    }
+
+    public static boolean isStartupGraceElapsed(long activatedAtMs) {
+        return !isInStartupGrace(activatedAtMs);
+    }
+
+    public static boolean shouldAcceptFinishReading(long activatedAtMs, boolean allowDuringStartup) {
+        return allowDuringStartup || isStartupGraceElapsed(activatedAtMs);
+    }
+
+    public static boolean isConfirmed(int finishReadingTicks) {
+        return finishReadingTicks >= TAB_FINISH_CONFIRM_TICKS;
+    }
+}

--- a/src/main/java/dev/aether/modules/pest/helpers/PestDestroyer.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestDestroyer.java
@@ -394,9 +394,7 @@ public class PestDestroyer {
     private static final long FIREWORK_CAPTURE_DURATION_MS = 1200;
     private static final double FIREWORK_EXTRAPOLATE_DISTANCE = 15.0;
     private static final long PLOT_TP_WAIT_MS = 2500;
-    private static final long STARTUP_FINISH_GRACE_MS = 5000;
     private static final long DISCO_PEST_SPAWN_GRACE_MS = 5000;
-    private static final int ZERO_PEST_TAB_CONFIRM_TICKS = 10;
     private static final int SKULL_MISSING_CONFIRM_TICKS = 3;
     private static final long ROOF_RESCAN_INTERVAL_MS = 1000L;
 
@@ -769,13 +767,13 @@ public class PestDestroyer {
         // Require consecutive confirmations to avoid one-tick tab desync noise.
         boolean lockedOnDiscoDestination = isLockedOnDiscoDestinationPlot(client);
         int aliveNow = lockedOnDiscoDestination ? -1 : PestManager.getEffectiveAliveCountNow(client);
-        boolean inStartupGrace = System.currentTimeMillis() - runtime.activatedAt < STARTUP_FINISH_GRACE_MS;
+        boolean inStartupGrace = PestCompletionGuard.isInStartupGrace(runtime.activatedAt);
 
         if (!lockedOnDiscoDestination
                 && aliveNow >= 0 && shouldFinishForAliveCount(client, aliveNow)
-                && (!inStartupGrace || isDiscoDestinationActive(client))) {
+                && PestCompletionGuard.shouldAcceptFinishReading(runtime.activatedAt, isDiscoDestinationActive(client))) {
             runtime.zeroPestTabTicks++;
-            if (runtime.zeroPestTabTicks >= ZERO_PEST_TAB_CONFIRM_TICKS) {
+            if (PestCompletionGuard.isConfirmed(runtime.zeroPestTabTicks)) {
                 ClientUtils.setKeyMappingState(client.options.keyUse, false);
                 ClientUtils.setKeyMappingState(client.options.keyDown, false);
                 ClientUtils.sendDebugMessage("PestDestroyer: tablist reports " + getAliveFinishReason(aliveNow) + ". Finishing.");
@@ -1143,7 +1141,7 @@ public class PestDestroyer {
             // No visible pests. Refresh infested plot data from tab.
             Set<String> rawInfested = PestManager.getInfestedPlotsFromTab(client);
             if (rawInfested.isEmpty()) {
-                if (System.currentTimeMillis() - runtime.activatedAt < STARTUP_FINISH_GRACE_MS) {
+                if (PestCompletionGuard.isInStartupGrace(runtime.activatedAt)) {
                     ClientUtils.sendDebugMessage("[PestDestroyer] Empty infested-plot tab data during startup grace. Retrying location scan.");
                     setState(State.GET_LOCATION);
                     return;
@@ -1586,7 +1584,7 @@ public class PestDestroyer {
         int aliveNow = PestManager.getEffectiveAliveCountNow(client);
         boolean onlyCurrentActivePlot = hasOnlyCurrentActiveInfestedPlot(client, currentPlot);
         boolean hasLocalEvidence = localPests > 0 || !runtime.killedEntities.isEmpty();
-        boolean startupGraceElapsed = System.currentTimeMillis() - runtime.activatedAt >= STARTUP_FINISH_GRACE_MS;
+        boolean startupGraceElapsed = PestCompletionGuard.isStartupGraceElapsed(runtime.activatedAt);
         boolean shouldSkip = localPests == 1
                 || (aliveNow == 1 && onlyCurrentActivePlot && (hasLocalEvidence || startupGraceElapsed));
         if (!shouldSkip) {


### PR DESCRIPTION
- add a short grace period after aotv usage to sync rotation so rotation failsafe isn't falsely triggered during aotv between pests
- remove autoLoadoutPest and autoLoadoutVisitor and reliance on it. loadout slots change are purely based on whether the slots differ now
- add PestCompletionGuard helper for Pest Manager, used in both automated pest destroyer and manual pest