### PR TITLE
fix(farming): reinitialize chopping input

### DIFF
--- a/src/main/java/dev/aether/macro/farming/AbstractFarmingMacro.java
+++ b/src/main/java/dev/aether/macro/farming/AbstractFarmingMacro.java
@@ -7,6 +7,7 @@ import dev.aether.modules.failsafe.FailsafeManager;
 import dev.aether.modules.farming.FastLaneSwitchManager;
 import dev.aether.modules.farming.SqueakyMousematManager;
 import dev.aether.modules.farming.UngrabMouse;
+import dev.aether.mixin.MixinMinecraft;
 import dev.aether.modules.rotation.RotationManager;
 import dev.aether.modules.visuals.FreecamManager;
 import dev.aether.util.ClientUtils;
@@ -298,8 +299,12 @@ public abstract class AbstractFarmingMacro extends AbstractMacro {
         ClientUtils.setKeyMappingState(opts.keyShift, sneak);
         ClientUtils.setKeyMappingState(opts.keySprint, sprint);
         ClientUtils.setKeyMappingState(opts.keyAttack, shouldAttack);
-        if (shouldAttack && !wasAttackHeldByMacro) {
-            ClientUtils.clickKeyMapping(opts.keyAttack);
+        if (shouldAttack) {
+            MixinMinecraft minecraft = (MixinMinecraft) mc;
+            minecraft.aether$setMissTime(0);
+            if (!wasAttackHeldByMacro) {
+                minecraft.aether$startAttack();
+            }
         }
     }
 


### PR DESCRIPTION
### Problem

`AbstractFarmingMacro` holds `keyAttack` but also calls `ClientUtils.clickKeyMapping()` when attacking starts. This synthetic click can get out of sync with Minecraft’s normal input state. If using Skyblocker, it may also produce a warning because the click isn’t in its physical pressed-key list.

Minecraft’s `missTime` can also temporarily suppress block breaking after mouse-grab or input transitions.

### Fix

Use the existing `MixinMinecraft` accessors to clear `missTime` while attack is held and call `Minecraft.startAttack()` once when attack begins. This removes the synthetic click path, starts chopping reliably, and doesn’t introduce spam-clicking.
​
​
​
​
​
_valen knows where to find me..._