### PR TITLE
makes Leave One Pest Alive work with multiple plots

### DIFF
--- a/src/main/java/dev/aether/bootstrap/AetherChatEvents.java
+++ b/src/main/java/dev/aether/bootstrap/AetherChatEvents.java
@@ -117,6 +117,7 @@ public final class AetherChatEvents {
 
         if (PestDestroyer.isActive()) {
             ClientUtils.sendDebugMessage("[PestDestroyer] Detected 'No Pests' message. Finishing destroyer.");
+            PestDestroyer.clearRememberedLeaveOnePlots();
             PestDestroyer.finish(Minecraft.getInstance());
         }
     }
@@ -223,6 +224,9 @@ public final class AetherChatEvents {
         }
 
         String plot = plotMatcher.group(1);
+        if (lowerText.contains("spawned")) {
+            PestDestroyer.onPestsSpawnedInPlot(plot);
+        }
         int spawnedCount = 0;
         Matcher spawnMatcher = SPAWN_COUNT_PATTERN.matcher(plainText);
         if (spawnMatcher.find()) {

--- a/src/main/java/dev/aether/modules/pest/PestManager.java
+++ b/src/main/java/dev/aether/modules/pest/PestManager.java
@@ -274,7 +274,8 @@ public class PestManager {
             return;
         }
 
-        if (isThresholdMet(effectiveAlive)) {
+        Set<String> actionablePlots = PestDestroyer.filterRememberedLeaveOnePlots(data.infestedPlots());
+        if (isThresholdMet(effectiveAlive) && !actionablePlots.isEmpty()) {
             if (isPestReentryCooldownActive()) {
                 return;
             }
@@ -294,9 +295,9 @@ public class PestManager {
             if (effectiveAlive >= 8 && effectiveAlive < 99) {
                 ClientUtils.sendMessage("\u00A7eMax Pests (8) reached. Starting cleaning...", true);
             }
-            setCurrentInfestedPlots(data.infestedPlots());
-            String targetPlot = data.infestedPlots().stream().findFirst().orElse(null);
-            ClientUtils.sendDebugMessage("[PestManager] Tab threshold met. infestedPlots=" + data.infestedPlots()
+            setCurrentInfestedPlots(actionablePlots);
+            String targetPlot = actionablePlots.stream().findFirst().orElse(null);
+            ClientUtils.sendDebugMessage("[PestManager] Tab threshold met. infestedPlots=" + actionablePlots
                             + " targetPlot=" + targetPlot + " currentPlot=" + ClientUtils.getCurrentPlot());
             boolean started = startCleaningSequence(client, targetPlot, effectiveAlive);
             if (started) {
@@ -402,11 +403,13 @@ public class PestManager {
             return false;
         }
 
-        Set<String> candidatePlots = new LinkedHashSet<>(data.infestedPlots());
+        Set<String> candidatePlots = new LinkedHashSet<>();
         String normalizedRequestedPlot = PestPlotId.normalize(requestedPlot);
         if (PestPlotId.isUsable(normalizedRequestedPlot)) {
             candidatePlots.add(normalizedRequestedPlot);
         }
+        candidatePlots.addAll(data.infestedPlots());
+        candidatePlots = PestDestroyer.filterRememberedLeaveOnePlots(candidatePlots);
 
         String targetPlot = candidatePlots.stream()
                 .findFirst()

--- a/src/main/java/dev/aether/modules/pest/helpers/PestCombatCoordinator.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestCombatCoordinator.java
@@ -189,7 +189,9 @@ final class PestCombatCoordinator {
         if (currentTarget == null || currentTarget.isRemoved() || (currentTarget instanceof LivingEntity le && le.isDeadOrDying())) {
             ClientUtils.setKeyMappingState(client.options.keyUse, false);
             if (currentTarget != null && (currentTarget.isRemoved() || (currentTarget instanceof LivingEntity le2 && le2.isDeadOrDying()))) {
-                context.recordTrackedPestKill(client, currentTarget);
+                if (context.recordTrackedPestKill(client, currentTarget)) {
+                    return;
+                }
             }
             context.setState(PestDestroyer.State.CHECK_NEXT);
             return;
@@ -255,7 +257,9 @@ final class PestCombatCoordinator {
                     ClientUtils.setKeyMappingState(client.options.keyUse, false);
                     ClientUtils.setKeyMappingState(client.options.keyDown, false);
                     context.markKilled(currentTarget);
-                    context.recordTrackedPestKill(client, currentTarget);
+                    if (context.recordTrackedPestKill(client, currentTarget)) {
+                        return;
+                    }
                     ClientUtils.sendDebugMessage("[PestDestroyer] Pest skull disappeared. Switching target immediately.");
                     if (!context.switchToNextQueuedTarget(client)) {
                         context.setState(PestDestroyer.State.CHECK_NEXT);

--- a/src/main/java/dev/aether/modules/pest/helpers/PestDestroyer.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestDestroyer.java
@@ -92,6 +92,7 @@ public class PestDestroyer {
             // Fallback to cached value
             infested = PestManager.getCurrentInfestedPlots();
         }
+        infested = PestLeaveOneController.filterSkippedPlots(runtime, infested);
 
         if (PestPlotId.isUsable(initialPlot)) {
             runtime.navigation.plotQueue.add(initialPlot);
@@ -165,6 +166,7 @@ public class PestDestroyer {
     }
 
     public static void reset() {
+        PestLeaveOneController.clearRememberedPlots(runtime);
         runtime.resetAll();
     }
 
@@ -469,6 +471,18 @@ public class PestDestroyer {
 
     static Set<String> filterSkippedInfestedPlots(Set<String> infested) {
         return PestLeaveOneController.filterSkippedPlots(runtime, infested);
+    }
+
+    public static Set<String> filterRememberedLeaveOnePlots(Set<String> infested) {
+        return PestLeaveOneController.filterSkippedPlots(runtime, infested);
+    }
+
+    public static void onPestsSpawnedInPlot(String plot) {
+        PestLeaveOneController.forgetPlot(runtime, plot);
+    }
+
+    public static void clearRememberedLeaveOnePlots() {
+        PestLeaveOneController.clearRememberedPlots(runtime);
     }
 
     private static boolean plotsEqual(String first, String second) {

--- a/src/main/java/dev/aether/modules/pest/helpers/PestDestroyerCoordinatorContext.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestDestroyerCoordinatorContext.java
@@ -17,8 +17,7 @@ final class PestDestroyerCoordinatorContext
                 PestHuntController.Context,
                 PestNavigationCoordinator.Context,
                 PestCombatCoordinator.Context,
-                PestDestroyerProgressController.Context,
-                PestLeaveOneController.Context {
+                PestDestroyerProgressController.Context {
     private final PestDestroyerRuntime runtime;
 
     PestDestroyerCoordinatorContext(PestDestroyerRuntime runtime) {
@@ -97,7 +96,7 @@ final class PestDestroyerCoordinatorContext
 
     @Override
     public Entity findClosestPest(Minecraft client) {
-        return PestTargetController.findClosestPest(client, runtime);
+        return PestTargetController.findClosestPest(client, runtime, this);
     }
 
     @Override
@@ -108,11 +107,6 @@ final class PestDestroyerCoordinatorContext
     @Override
     public int countVisiblePestSkulls(Minecraft client) {
         return PestTargetController.countVisiblePestSkulls(client);
-    }
-
-    @Override
-    public int countAvailablePests(Minecraft client) {
-        return PestTargetController.countAvailablePests(client, runtime);
     }
 
     @Override

--- a/src/main/java/dev/aether/modules/pest/helpers/PestDestroyerProgressController.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestDestroyerProgressController.java
@@ -72,7 +72,9 @@ final class PestDestroyerProgressController {
             if (!infested.isEmpty()) {
                 String firstPlot = infested.iterator().next();
                 String currentPlot = context.getEffectivePlot(client);
-                if (!context.plotsEqual(firstPlot, currentPlot)
+                boolean currentStillActionable = infested.stream()
+                        .anyMatch(plot -> context.plotsEqual(plot, currentPlot));
+                if (!currentStillActionable
                         && isImmediatePlotExitState(runtime.state)) {
                     ClientUtils.sendDebugMessage(
                             "[PestDestroyer] Plot "

--- a/src/main/java/dev/aether/modules/pest/helpers/PestHuntController.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestHuntController.java
@@ -37,7 +37,7 @@ final class PestHuntController {
 
         Entity pest = PestTargetController.nextQueuedPest(client, runtime);
         if (pest == null) {
-            PestTargetController.rebuildQueue(client, runtime);
+            PestTargetController.rebuildQueue(client, runtime, targetContext);
             pest = PestTargetController.nextQueuedPest(client, runtime);
         }
         if (pest != null) {
@@ -69,10 +69,16 @@ final class PestHuntController {
         }
 
         runtime.navigation.plotQueue.clear();
-        runtime.navigation.plotQueue.addAll(infested);
-        String firstPlot = runtime.navigation.plotQueue.getFirst();
         String currentPlot =
                 PestPlotNavigator.getEffectivePlot(client, runtime.navigation);
+        infested.stream()
+                .filter(plot -> PestPlotId.equals(plot, currentPlot))
+                .findFirst()
+                .ifPresent(runtime.navigation.plotQueue::add);
+        infested.stream()
+                .filter(plot -> !PestPlotId.equals(plot, currentPlot))
+                .forEach(runtime.navigation.plotQueue::add);
+        String firstPlot = runtime.navigation.plotQueue.getFirst();
 
         if (!PestPlotId.equals(firstPlot, currentPlot)) {
             runtime.navigation.currentPlotIdx = 0;

--- a/src/main/java/dev/aether/modules/pest/helpers/PestLeaveOneController.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestLeaveOneController.java
@@ -7,16 +7,18 @@ import dev.aether.util.ClientUtils;
 import net.minecraft.client.Minecraft;
 
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /** Encapsulates the optional "leave one pest alive" plot policy. */
 final class PestLeaveOneController {
+    private static final Pattern PLOT_PEST_COUNT =
+            Pattern.compile("(?i)\\bplot\\s*[-:#]?\\s*(\\d+)\\D+?x\\s*(\\d+)\\b");
+
     interface Context {
         String getEffectivePlot(Minecraft client);
-
-        int countAvailablePests(Minecraft client);
-
-        int countVisiblePestSkulls(Minecraft client);
 
         void setState(PestDestroyer.State state);
     }
@@ -32,25 +34,16 @@ final class PestLeaveOneController {
             return false;
         }
         if (aliveCount == 0) {
+            runtime.navigation.leaveOneSkippedPlots.clear();
             return true;
         }
         if (!AetherConfig.LEAVE_ONE_PEST_ALIVE.get()) {
+            resetTracking(runtime);
             return false;
         }
-
-        Set<String> leaveOnePlots =
-                new LinkedHashSet<>(runtime.navigation.leaveOneSkippedPlots);
-        for (String plot : PestManager.getInfestedPlotsFromTab(client)) {
-            String normalized = PestPlotId.normalize(plot);
-            if (runtime.navigation.leaveOneSkippedPlots.contains(normalized)) {
-                continue;
-            }
-            if (!isWhitelistedPlot(plot)) {
-                return false;
-            }
-            leaveOnePlots.add(normalized);
-        }
-        return !leaveOnePlots.isEmpty() && aliveCount <= leaveOnePlots.size();
+        pruneRememberedPlots(runtime);
+        return shouldFinishForCounts(
+                aliveCount, runtime.navigation.leaveOneSkippedPlots.size());
     }
 
     static boolean tryLeaveCurrentPlot(
@@ -63,6 +56,7 @@ final class PestLeaveOneController {
 
         String currentPlot = context.getEffectivePlot(client);
         if (!isWhitelistedPlot(currentPlot)) {
+            resetTracking(runtime);
             return false;
         }
 
@@ -71,32 +65,64 @@ final class PestLeaveOneController {
             return false;
         }
 
-        int localPests = Math.max(
-                context.countAvailablePests(client),
-                context.countVisiblePestSkulls(client));
-        int aliveNow = PestManager.getEffectiveAliveCountNow(client);
-        boolean hasLocalEvidence = localPests > 0 || !runtime.killedEntities.isEmpty();
-        boolean shouldSkip = localPests == 1
-                || (aliveNow == 1
-                        && hasOnlyCurrentActivePlot(client, runtime, currentPlot)
-                        && (hasLocalEvidence
-                                || PestCompletionGuard.isStartupGraceElapsed(runtime.activatedAt)));
-        if (!shouldSkip) {
-            return false;
+        int plotPests = parsePlotPestCount(ClientUtils.getSidebarLines(), currentPlot);
+        if (!normalized.equals(runtime.navigation.leaveOneTrackedPlot)) {
+            runtime.navigation.leaveOneTrackedPlot = normalized;
+            runtime.navigation.leaveOneRemainingKills = -1;
+            runtime.navigation.leaveOneUnbudgetedKills = 0;
+            runtime.navigation.leaveOneReservedEntityId = -1;
+        }
+        if (runtime.navigation.leaveOneRemainingKills < 0 && plotPests > 0) {
+            runtime.navigation.leaveOneRemainingKills = remainingKillBudget(
+                    plotPests, runtime.navigation.leaveOneUnbudgetedKills);
+            ClientUtils.sendDebugMessage(
+                    "PestDestroyer: Plot "
+                            + currentPlot
+                            + " leave-one kill budget is "
+                            + runtime.navigation.leaveOneRemainingKills
+                            + " after "
+                            + runtime.navigation.leaveOneUnbudgetedKills
+                            + " early kill(s).");
         }
 
-        runtime.navigation.leaveOneSkippedPlots.add(normalized);
-        ClientUtils.sendDebugMessage(
-                "PestDestroyer: leaving one pest alive on whitelisted plot "
-                        + currentPlot
-                        + ".");
-        moveToNextActivePlotOrFinish(client, runtime, context);
-        return true;
+        return (plotPests == 1 || runtime.navigation.leaveOneRemainingKills == 0)
+                && finishCurrentPlot(client, runtime, context, currentPlot);
+    }
+
+    static boolean recordTrackedKill(
+            Minecraft client,
+            PestDestroyerRuntime runtime,
+            Context context) {
+        String currentPlot = context.getEffectivePlot(client);
+        if (!isWhitelistedPlot(currentPlot)) {
+            return false;
+        }
+        String normalized = PestPlotId.normalize(currentPlot);
+        if (!normalized.equals(runtime.navigation.leaveOneTrackedPlot)) {
+            runtime.navigation.leaveOneTrackedPlot = normalized;
+            runtime.navigation.leaveOneRemainingKills = -1;
+            runtime.navigation.leaveOneUnbudgetedKills = 0;
+            runtime.navigation.leaveOneReservedEntityId = -1;
+        }
+        if (runtime.navigation.leaveOneRemainingKills < 0) {
+            runtime.navigation.leaveOneUnbudgetedKills++;
+            return false;
+        }
+        runtime.navigation.leaveOneRemainingKills =
+                consumeKillBudget(runtime.navigation.leaveOneRemainingKills);
+        return runtime.navigation.leaveOneRemainingKills == 0
+                && finishCurrentPlot(client, runtime, context, currentPlot);
+    }
+
+    static boolean isTrackingPlot(PestDestroyerRuntime runtime, String plot) {
+        return runtime.navigation.leaveOneRemainingKills >= 0
+                && PestPlotId.equals(runtime.navigation.leaveOneTrackedPlot, plot);
     }
 
     static Set<String> filterSkippedPlots(
             PestDestroyerRuntime runtime,
             Set<String> infested) {
+        pruneRememberedPlots(runtime);
         Set<String> filtered = new LinkedHashSet<>();
         for (String plot : infested) {
             if (!runtime.navigation.leaveOneSkippedPlots.contains(PestPlotId.normalize(plot))) {
@@ -104,6 +130,61 @@ final class PestLeaveOneController {
             }
         }
         return filtered;
+    }
+
+    static void forgetPlot(PestDestroyerRuntime runtime, String plot) {
+        String normalized = PestPlotId.normalize(plot);
+        runtime.navigation.leaveOneSkippedPlots.remove(normalized);
+        if (normalized.equals(runtime.navigation.leaveOneTrackedPlot)) {
+            resetTracking(runtime);
+        }
+    }
+
+    static void clearRememberedPlots(PestDestroyerRuntime runtime) {
+        runtime.navigation.leaveOneSkippedPlots.clear();
+        resetTracking(runtime);
+    }
+
+    static boolean shouldFinishForCounts(int aliveCount, int rememberedPlotCount) {
+        return aliveCount == 0 || rememberedPlotCount > 0 && aliveCount <= rememberedPlotCount;
+    }
+
+    static int parsePlotPestCount(List<String> lines, String plot) {
+        String normalizedPlot = PestPlotId.normalize(plot);
+        for (String line : lines) {
+            Matcher matcher = PLOT_PEST_COUNT.matcher(line);
+            if (matcher.find() && PestPlotId.normalize(matcher.group(1)).equals(normalizedPlot)) {
+                return Integer.parseInt(matcher.group(2));
+            }
+        }
+        return -1;
+    }
+
+    static int killBudgetForCount(int pestCount) {
+        return pestCount > 0 ? pestCount - 1 : -1;
+    }
+
+    static int consumeKillBudget(int remainingKills) {
+        return remainingKills > 0 ? remainingKills - 1 : remainingKills;
+    }
+
+    static int remainingKillBudget(int pestCount, int earlyKills) {
+        return Math.max(0, killBudgetForCount(pestCount) - Math.max(0, earlyKills));
+    }
+
+    private static boolean finishCurrentPlot(
+            Minecraft client,
+            PestDestroyerRuntime runtime,
+            Context context,
+            String currentPlot) {
+        runtime.navigation.leaveOneSkippedPlots.add(PestPlotId.normalize(currentPlot));
+        resetTracking(runtime);
+        ClientUtils.sendDebugMessage(
+                "PestDestroyer: leaving one pest alive on whitelisted plot "
+                        + currentPlot
+                        + ".");
+        moveToNextActivePlotOrFinish(client, runtime, context);
+        return true;
     }
 
     private static void moveToNextActivePlotOrFinish(
@@ -148,15 +229,24 @@ final class PestLeaveOneController {
         context.setState(PestDestroyer.State.CHECK_NEXT);
     }
 
-    private static boolean hasOnlyCurrentActivePlot(
-            Minecraft client,
-            PestDestroyerRuntime runtime,
-            String currentPlot) {
-        Set<String> active = filterSkippedPlots(
-                runtime,
-                PestManager.getInfestedPlotsFromTab(client));
-        return active.size() == 1
-                && PestPlotId.equals(active.iterator().next(), currentPlot);
+    private static void pruneRememberedPlots(PestDestroyerRuntime runtime) {
+        if (!AetherConfig.LEAVE_ONE_PEST_ALIVE.get()) {
+            runtime.navigation.leaveOneSkippedPlots.clear();
+            resetTracking(runtime);
+            return;
+        }
+        Set<String> configured = new LinkedHashSet<>();
+        for (String plot : AetherConfig.LEAVE_ONE_PEST_PLOTS.get()) {
+            configured.add(PestPlotId.normalize(plot));
+        }
+        runtime.navigation.leaveOneSkippedPlots.retainAll(configured);
+    }
+
+    private static void resetTracking(PestDestroyerRuntime runtime) {
+        runtime.navigation.leaveOneTrackedPlot = null;
+        runtime.navigation.leaveOneRemainingKills = -1;
+        runtime.navigation.leaveOneUnbudgetedKills = 0;
+        runtime.navigation.leaveOneReservedEntityId = -1;
     }
 
     private static boolean isWhitelistedPlot(String plot) {

--- a/src/main/java/dev/aether/modules/pest/helpers/PestNavigationState.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestNavigationState.java
@@ -22,6 +22,10 @@ final class PestNavigationState {
     CommandUtils.ChatWindow plotTpWindow = null;
     final List<String> plotQueue = new ArrayList<>();
     final Set<String> leaveOneSkippedPlots = ConcurrentHashMap.newKeySet();
+    String leaveOneTrackedPlot = null;
+    int leaveOneRemainingKills = -1;
+    int leaveOneUnbudgetedKills = 0;
+    int leaveOneReservedEntityId = -1;
     int currentPlotIdx = 0;
     String lastTargetPlot = null;
     String trustedPlot = null;
@@ -39,7 +43,10 @@ final class PestNavigationState {
         plotTpSent = false;
         plotTpWindow = null;
         plotQueue.clear();
-        leaveOneSkippedPlots.clear();
+        leaveOneTrackedPlot = null;
+        leaveOneRemainingKills = -1;
+        leaveOneUnbudgetedKills = 0;
+        leaveOneReservedEntityId = -1;
         currentPlotIdx = 0;
         lastTargetPlot = null;
         trustedPlot = null;

--- a/src/main/java/dev/aether/modules/pest/helpers/PestTargetController.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestTargetController.java
@@ -23,10 +23,8 @@ final class PestTargetController {
             TARGET_REACH_DISTANCE * PRE_TRIGGER_RATIO;
     private static final double PRE_MOVE_MIN_NEXT_DIST = 2.5;
 
-    interface Context {
+    interface Context extends PestLeaveOneController.Context {
         boolean tryLeaveOneOnCurrentPlot(Minecraft client);
-
-        void setState(PestDestroyer.State state);
     }
 
     private PestTargetController() {
@@ -95,7 +93,7 @@ final class PestTargetController {
 
         Entity next = nextQueuedPest(client, runtime);
         if (next == null) {
-            rebuildQueue(client, runtime);
+            rebuildQueue(client, runtime, context);
             next = nextQueuedPest(client, runtime);
         }
         if (next == null) {
@@ -125,9 +123,16 @@ final class PestTargetController {
                 client, runtime.pestTargetQueue, runtime.killedEntities);
     }
 
-    static void rebuildQueue(Minecraft client, PestDestroyerRuntime runtime) {
+    static void rebuildQueue(
+            Minecraft client,
+            PestDestroyerRuntime runtime,
+            Context context) {
+        updateReservedPest(client, runtime, context);
         PestTargetTracker.rebuildPestTargetQueue(
-                client, runtime.pestTargetQueue, runtime.killedEntities);
+                client,
+                runtime.pestTargetQueue,
+                runtime.killedEntities,
+                runtime.navigation.leaveOneReservedEntityId);
     }
 
     static Entity nextQueuedPest(Minecraft client, PestDestroyerRuntime runtime) {
@@ -135,16 +140,19 @@ final class PestTargetController {
                 client, runtime.pestTargetQueue, runtime.killedEntities);
     }
 
-    static Entity findClosestPest(Minecraft client, PestDestroyerRuntime runtime) {
-        return PestTargetTracker.findClosestPest(client, runtime.killedEntities);
+    static Entity findClosestPest(
+            Minecraft client,
+            PestDestroyerRuntime runtime,
+            Context context) {
+        updateReservedPest(client, runtime, context);
+        return PestTargetTracker.findClosestPest(
+                client,
+                runtime.killedEntities,
+                runtime.navigation.leaveOneReservedEntityId);
     }
 
     static int countVisiblePestSkulls(Minecraft client) {
         return PestTargetTracker.countVisiblePestSkulls(client);
-    }
-
-    static int countAvailablePests(Minecraft client, PestDestroyerRuntime runtime) {
-        return PestTargetTracker.countAvailablePests(client, runtime.killedEntities);
     }
 
     static boolean hasPestSkullMarkerForTarget(Minecraft client, Entity target) {
@@ -191,7 +199,29 @@ final class PestTargetController {
             return false;
         }
         PestManager.decrementPredictedAliveCount(client);
-        return false;
+        return PestLeaveOneController.recordTrackedKill(client, runtime, context);
+    }
+
+    private static void updateReservedPest(
+            Minecraft client,
+            PestDestroyerRuntime runtime,
+            Context context) {
+        if (!PestLeaveOneController.isTrackingPlot(
+                runtime, context.getEffectivePlot(client))) {
+            runtime.navigation.leaveOneReservedEntityId = -1;
+            return;
+        }
+        int reservedId = runtime.navigation.leaveOneReservedEntityId;
+        boolean reservedStillAvailable = reservedId != -1
+                && PestTargetTracker.isAvailablePest(
+                        client, runtime.killedEntities, reservedId);
+        Entity reserved = PestTargetTracker.findMostIsolatedPest(
+                client, runtime.killedEntities);
+        if (reserved != null) {
+            runtime.navigation.leaveOneReservedEntityId = reserved.getId();
+        } else if (!reservedStillAvailable) {
+            runtime.navigation.leaveOneReservedEntityId = -1;
+        }
     }
 
     static boolean isLookingAt(Minecraft client, Vec3 targetPosition, float tolerance) {

--- a/src/main/java/dev/aether/modules/pest/helpers/PestTargetTracker.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestTargetTracker.java
@@ -21,6 +21,7 @@ import java.util.Deque;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.IdentityHashMap;
 import java.util.function.Predicate;
 
 public final class PestTargetTracker {
@@ -79,10 +80,21 @@ public final class PestTargetTracker {
     static void rebuildPestTargetQueue(
             Minecraft client,
             Deque<Entity> pestTargetQueue,
-            Collection<Entity> killedEntities
+            Collection<Entity> killedEntities,
+            int reservedEntityId
     ) {
         List<Entity> pests = availableTargets(client, killedEntities);
-        if (client.player != null) {
+        if (reservedEntityId != -1) {
+            Map<Entity, Double> nearestNeighborDistances = new IdentityHashMap<>();
+            List<Vec3> positions = pests.stream().map(Entity::position).toList();
+            for (int i = 0; i < pests.size(); i++) {
+                nearestNeighborDistances.put(pests.get(i), nearestNeighborDistanceSqr(i, positions));
+            }
+            pests.removeIf(pest -> pest.getId() == reservedEntityId);
+            pests.sort(Comparator
+                    .comparingDouble((Entity pest) -> nearestNeighborDistances.get(pest))
+                    .thenComparingDouble(client.player::distanceToSqr));
+        } else if (client.player != null) {
             pests.sort(Comparator.comparingDouble(client.player::distanceToSqr));
         }
         pestTargetQueue.clear();
@@ -93,16 +105,16 @@ public final class PestTargetTracker {
         }
     }
 
-    static int countAvailablePests(Minecraft client, Collection<Entity> killedEntities) {
-        return availableTargets(client, killedEntities).size();
-    }
-
-    static Entity findClosestPest(Minecraft client, Collection<Entity> killedEntities) {
+    static Entity findClosestPest(
+            Minecraft client,
+            Collection<Entity> killedEntities,
+            int reservedEntityId) {
         if (client == null || client.player == null) {
             return null;
         }
         List<Entity> targets = availableTargets(client, killedEntities);
         Entity closest = targets.stream()
+                .filter(target -> target.getId() != reservedEntityId)
                 .min(Comparator.comparingDouble(client.player::distanceToSqr))
                 .orElse(null);
         PestSnapshot snapshot = snapshot(client);
@@ -110,6 +122,47 @@ public final class PestTargetTracker {
                 + " entities, " + snapshot.markers().size() + " pest markers, "
                 + targets.size() + " available pests");
         return closest;
+    }
+
+    static Entity findMostIsolatedPest(Minecraft client, Collection<Entity> killedEntities) {
+        List<Entity> pests = availableTargets(client, killedEntities);
+        if (pests.size() < 2) {
+            return null;
+        }
+        List<Vec3> positions = pests.stream().map(Entity::position).toList();
+        return pests.get(mostIsolatedIndex(positions));
+    }
+
+    static boolean isAvailablePest(
+            Minecraft client,
+            Collection<Entity> killedEntities,
+            int entityId) {
+        return availableTargets(client, killedEntities).stream()
+                .anyMatch(pest -> pest.getId() == entityId);
+    }
+
+    // ponytail: O(n^2) is simpler and pests are single-digit; spatial indexing only if that ceiling changes.
+    static int mostIsolatedIndex(List<Vec3> positions) {
+        int mostIsolated = -1;
+        double bestDistance = -1.0;
+        for (int i = 0; i < positions.size(); i++) {
+            double distance = nearestNeighborDistanceSqr(i, positions);
+            if (distance > bestDistance) {
+                bestDistance = distance;
+                mostIsolated = i;
+            }
+        }
+        return mostIsolated;
+    }
+
+    private static double nearestNeighborDistanceSqr(int index, List<Vec3> positions) {
+        double nearest = Double.MAX_VALUE;
+        for (int i = 0; i < positions.size(); i++) {
+            if (i != index) {
+                nearest = Math.min(nearest, positions.get(index).distanceToSqr(positions.get(i)));
+            }
+        }
+        return nearest;
     }
 
     static boolean hasPestArmorStandNearby(Minecraft client, Entity targetEntity) {

--- a/src/main/java/dev/aether/util/ClientUtils.java
+++ b/src/main/java/dev/aether/util/ClientUtils.java
@@ -57,7 +57,7 @@ public class ClientUtils {
     private static final int JACOBS_CONTEST_START_MINUTE_UTC = 15;
     private static final int JACOBS_CONTEST_END_MINUTE_UTC = 35;
     private static final Object SIDEBAR_CACHE_LOCK = new Object();
-    private static final Pattern STRIP_SCOREBOARD_FORMATTING = Pattern.compile("(?i)\u00A7[0-9A-FK-ORZ]");
+    private static final Pattern STRIP_SCOREBOARD_FORMATTING = Pattern.compile("\u00A7.");
     private static final Pattern STRIP_MINECRAFT_FORMATTING = Pattern.compile("(?i)\u00A7[0-9A-FK-ORZ]");
     private static final DateTimeFormatter DEBUG_LOG_FILE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd-HH_mm'.txt'");
     private static final DateTimeFormatter DEBUG_LOG_LINE_TIME_FORMAT = DateTimeFormatter.ofPattern("HH:mm:ss");

--- a/src/test/java/dev/aether/modules/pest/helpers/PestLeaveOneControllerTest.java
+++ b/src/test/java/dev/aether/modules/pest/helpers/PestLeaveOneControllerTest.java
@@ -1,0 +1,31 @@
+package dev.aether.modules.pest.helpers;
+
+import org.junit.jupiter.api.Test;
+import net.minecraft.world.phys.Vec3;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PestLeaveOneControllerTest {
+    @Test
+    void parsesCurrentPlotCountAndOnlyFinishesForRememberedPlots() {
+        List<String> sidebar = List.of("The Garden x6", "Plot - 15 x4");
+
+        assertEquals(4, PestLeaveOneController.parsePlotPestCount(sidebar, "15"));
+        assertEquals(-1, PestLeaveOneController.parsePlotPestCount(sidebar, "17"));
+        assertFalse(PestLeaveOneController.shouldFinishForCounts(1, 0));
+        assertFalse(PestLeaveOneController.shouldFinishForCounts(2, 1));
+        assertTrue(PestLeaveOneController.shouldFinishForCounts(2, 2));
+        assertEquals(5, PestLeaveOneController.killBudgetForCount(6));
+        assertEquals(4, PestLeaveOneController.consumeKillBudget(5));
+        assertEquals(0, PestLeaveOneController.consumeKillBudget(0));
+        assertEquals(2, PestLeaveOneController.remainingKillBudget(4, 1));
+        assertEquals(2, PestTargetTracker.mostIsolatedIndex(List.of(
+                new Vec3(0, 0, 0),
+                new Vec3(1, 0, 0),
+                new Vec3(10, 0, 0))));
+    }
+}


### PR DESCRIPTION
Tracks plots with 1 pest that are in the allowlist so it doesn't waste time tping to them them when it clears pests (will untrack it if there's chat messages says new pests spawned there and then track it again when it kills all but one in that plot)
uses scoreboard pest count to calculate how many pests need to be killed in leave-one plots (also counts kills before the scoreboard updates after warps in case you tp to a plot and kill a pest before the plot's pest count shows up on scoreboard.)
prioritizes clustered pests and reserves the most isolated pest so that you won't accidentally kill all the pests in a plot (as frequently, probably not possible to fully avoid because max vacuum has pretty big range)
