### PR TITLE
Add Ballsack Shredder support + various bug fixes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Aether artifact version
-aether_version = 1.1.4
+aether_version = 1.1.5
 
 org.gradle.jvmargs = -Xmx2g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
 

--- a/src/main/java/dev/aether/bootstrap/AetherChatEvents.java
+++ b/src/main/java/dev/aether/bootstrap/AetherChatEvents.java
@@ -234,23 +234,10 @@ public final class AetherChatEvents {
         }
 
         final int parsedSpawnedCount = spawnedCount;
-        MacroWorkerThread.getInstance().submit("PestClean-ChatTrigger-" + plot, () -> {
-            if (MacroWorkerThread.shouldAbortTask(Minecraft.getInstance(), MacroState.State.FARMING)) {
-                return;
-            }
-
-            int triggerDelay = ConfigHelpers.getRandomizedDelay(
-                    AetherConfig.PEST_CHAT_TRIGGER_DELAY_MIN.get(),
-                    AetherConfig.PEST_CHAT_TRIGGER_DELAY_MAX.get());
-            if (triggerDelay > 0) {
-                MacroWorkerThread.sleep(triggerDelay);
-                if (MacroWorkerThread.shouldAbortTask(Minecraft.getInstance(), MacroState.State.FARMING)) {
-                    return;
-                }
-            }
-
-            PestManager.tryStartCleaningSequenceFromChat(Minecraft.getInstance(), plot, parsedSpawnedCount);
-        });
+        int triggerDelay = ConfigHelpers.getRandomizedDelay(
+                AetherConfig.PEST_CHAT_TRIGGER_DELAY_MIN.get(),
+                AetherConfig.PEST_CHAT_TRIGGER_DELAY_MAX.get());
+        PestManager.scheduleChatCleaningTrigger(plot, parsedSpawnedCount, triggerDelay);
     }
 
     private static void handleStashState(String lowerText) {

--- a/src/main/java/dev/aether/bootstrap/AetherChatEvents.java
+++ b/src/main/java/dev/aether/bootstrap/AetherChatEvents.java
@@ -117,6 +117,7 @@ public final class AetherChatEvents {
 
         if (PestDestroyer.isActive()) {
             ClientUtils.sendDebugMessage("[PestDestroyer] Detected 'No Pests' message. Finishing destroyer.");
+            PestDestroyer.clearRememberedLeaveOnePlots();
             PestDestroyer.finish(Minecraft.getInstance());
         }
     }
@@ -223,6 +224,9 @@ public final class AetherChatEvents {
         }
 
         String plot = plotMatcher.group(1);
+        if (lowerText.contains("spawned")) {
+            PestDestroyer.onPestsSpawnedInPlot(plot);
+        }
         int spawnedCount = 0;
         Matcher spawnMatcher = SPAWN_COUNT_PATTERN.matcher(plainText);
         if (spawnMatcher.find()) {

--- a/src/main/java/dev/aether/config/AetherConfig.java
+++ b/src/main/java/dev/aether/config/AetherConfig.java
@@ -417,9 +417,9 @@ public final class AetherConfig {
         public static final BooleanEntry TRIGGER_PEST_ON_CHAT = Config.bool("triggerPestOnChat", true);
         public static final BooleanEntry PEST_TRIGGER_ONLY_AFTER_REWARP = Config.bool("pestTriggerOnlyAfterRewarp", false);
         public static final IntEntry PEST_CHAT_TRIGGER_DELAY_MIN = Config.integer("pestChatTriggerDelayMin", 500)
-                        .range(0, 5000);
+                        .range(0, 30000);
         public static final IntEntry PEST_CHAT_TRIGGER_DELAY_MAX = Config.integer("pestChatTriggerDelayMax", 3000)
-                        .range(0, 5000);
+                        .range(0, 30000);
         public static final BooleanEntry DELAY_PEST_FOR_CROP_FEVER = Config.bool("delayPestForCropFever", false);
         public static final BooleanEntry PEST_ON_TRACK_ENABLED = Config.bool("pestOnTrackEnabled", false);
         // start: farmhelper ish pest on track
@@ -537,7 +537,7 @@ public final class AetherConfig {
         // -- AOTV ------------------------------------------------------------------
 
         public static final BooleanEntry AOTV_TO_ROOF = Config.bool("aotvToRoof", false);
-        public static final IntEntry AOTV_ROOF_PITCH = Config.integer("aotvRoofPitch", 88).range(20, 90);
+        public static final IntEntry AOTV_ROOF_PITCH = Config.integer("aotvRoofPitch", 88).range(0, 90);
         public static final IntEntry AOTV_ROOF_PITCH_HUMANIZATION = Config.integer("aotvRoofPitchHumanization", 5)
                         .range(0, 15);
         public static final ListEntry<String> AOTV_ROOF_PLOTS = Config.list("aotvRoofPlots", Collections.emptyList(),

--- a/src/main/java/dev/aether/config/AetherConfig.java
+++ b/src/main/java/dev/aether/config/AetherConfig.java
@@ -447,6 +447,9 @@ public final class AetherConfig {
         public static final ListEntry<String> LEAVE_ONE_PEST_PLOTS = Config.list("leaveOnePestPlots",
                         Collections.emptyList(), String.class);
         public static final BooleanEntry SUNSET_PESTS = Config.bool("sunsetPests", false);
+        public static final BooleanEntry BALLSACK_SHREDDER = Config.bool("ballsackShredder", false);
+        public static final IntEntry BALLSACK_LOOK_DOWN_TIME_MS = Config.integer("ballsackLookDownTimeMs", 1000)
+                        .range(0, 3000);
         public static final BooleanEntry PEST_AOTV_BETWEEN = Config.bool("pestAotvBetween", false);
         public static final BooleanEntry PEST_AOTV_CONFIRM_BETWEEN = Config.bool("pestAotvConfirmBetween", false);
         public static final IntEntry PEST_AOTV_DELAY_MIN = Config.integer("pestAotvDelayMin", 150).range(100, 250);

--- a/src/main/java/dev/aether/modules/gear/helpers/LoadoutManager.java
+++ b/src/main/java/dev/aether/modules/gear/helpers/LoadoutManager.java
@@ -89,7 +89,7 @@ public class LoadoutManager {
             if (MacroWorkerThread.shouldAbortTask(client)) {
                 return;
             }
-            MacroWorkerThread.sleep(375);
+            MacroWorkerThread.sleep(400);
             if (MacroWorkerThread.shouldAbortTask(client)) {
                 return;
             }

--- a/src/main/java/dev/aether/modules/gear/helpers/LoadoutManager.java
+++ b/src/main/java/dev/aether/modules/gear/helpers/LoadoutManager.java
@@ -25,7 +25,9 @@ public class LoadoutManager {
     public static volatile long loadoutOpenPendingTime = 0;
     public static volatile long loadoutFirstClickDelayMs = 0;
     public static volatile boolean loadoutGuiDetected = false;
+    public static volatile boolean loadoutGuiCloseComplete = true;
     public static volatile long loadoutTimelineStartTime = 0;
+    private static volatile long loadoutRequestId = 0;
 
     public static void resetState() {
         isSwappingLoadout = false;
@@ -36,13 +38,19 @@ public class LoadoutManager {
         loadoutInteractionTime = 0;
         loadoutInteractionStage = 0;
         loadoutGuiDetected = false;
+        loadoutGuiCloseComplete = true;
+        loadoutRequestId++;
         loadoutOpenPendingTime = 0;
         loadoutFirstClickDelayMs = 0;
         loadoutTimelineStartTime = 0;
     }
 
     public static void triggerLoadoutSwap(Minecraft client, int slot) {
-        if (trackedLoadoutSlot == slot || (isSwappingLoadout && targetLoadoutSlot == slot)) {
+        if (isSwappingLoadout && targetLoadoutSlot == slot) {
+            ClientUtils.sendDebugMessage("Loadout swap to slot " + slot + " is already pending.");
+            return;
+        }
+        if (trackedLoadoutSlot == slot) {
             ClientUtils.sendDebugMessage("Loadout already on target slot, restarting farming");
             client.execute(() -> FarmingMacroManager.disable(client));
             MacroWorkerThread.getInstance().submit("Wardrobe-AlreadyOnSlot-FastResume", () -> {
@@ -74,8 +82,10 @@ public class LoadoutManager {
         }
 
         targetLoadoutSlot = slot;
+        long requestId = ++loadoutRequestId;
         isSwappingLoadout = true;
         loadoutGuiDetected = false;
+        loadoutGuiCloseComplete = false;
         loadoutInteractionTime = 0;
         loadoutInteractionStage = 0;
         loadoutTimelineStartTime = 0;
@@ -85,16 +95,10 @@ public class LoadoutManager {
         MacroStateManager.setCurrentState(MacroState.State.WARDROBE);
         ClientUtils.sendDebugMessage("Triggering loadout swap to slot " + slot);
         client.execute(() -> FarmingMacroManager.disable(client));
-        MacroWorkerThread.getInstance().submit("Loadout-OpenGui", () -> {
-            if (MacroWorkerThread.shouldAbortTask(client)) {
-                return;
+        ClientUtils.scheduleClientTask(client, 400L, () -> {
+            if (isSwappingLoadout && targetLoadoutSlot == slot && loadoutRequestId == requestId) {
+                ClientUtils.sendCommand("/loadout");
             }
-            MacroWorkerThread.sleep(400);
-            if (MacroWorkerThread.shouldAbortTask(client)) {
-                return;
-            }
-            client.execute(() -> ClientUtils.sendCommand("/loadout"));
-            ClientUtils.waitForWardrobeGui();
         });
     }
 
@@ -103,8 +107,10 @@ public class LoadoutManager {
             return;
         }
         targetLoadoutSlot = slot;
+        loadoutRequestId++;
         isSwappingLoadout = true;
         loadoutGuiDetected = false;
+        loadoutGuiCloseComplete = false;
         loadoutInteractionTime = 0;
         loadoutInteractionStage = 0;
         loadoutTimelineStartTime = 0;
@@ -121,6 +127,7 @@ public class LoadoutManager {
         isSwappingLoadout = false;
         shouldRestartFarmingAfterSwap = false;
         loadoutGuiDetected = false;
+        loadoutGuiCloseComplete = false;
         loadoutInteractionTime = 0;
         loadoutInteractionStage = 0;
         loadoutTimelineStartTime = 0;
@@ -132,9 +139,8 @@ public class LoadoutManager {
         }
 
         ClientUtils.sendDebugMessage("Aborted loadout swap because " + taskName + " has priority.");
-        if (client.player != null) {
-            client.execute(() -> client.player.closeContainer());
-        }
+        ClientUtils.closeGui(client);
+        loadoutGuiCloseComplete = true;
     }
 
     public static void handleLoadoutMenu(Minecraft client, AbstractContainerScreen<?> screen) {
@@ -202,13 +208,13 @@ public class LoadoutManager {
         loadoutOpenPendingTime = 0;
         loadoutFirstClickDelayMs = 0;
 
-        if (client.player != null) {
-            sendTimedDebug(client, "Loadout GUI close requested", now);
-            client.player.closeContainer();
-        }
-
-        sendTimedDebug(client, "Loadout swap complete. Active slot is now " + trackedLoadoutSlot, now);
-        handleLoadoutCompletion(client);
+        sendTimedDebug(client, "Loadout GUI close requested", now);
+        ClientUtils.closeGuiAsync(client).thenRun(() -> {
+            loadoutGuiCloseComplete = true;
+            sendTimedDebug(client, "Loadout swap complete. Active slot is now " + trackedLoadoutSlot,
+                    System.currentTimeMillis());
+            handleLoadoutCompletion(client);
+        });
     }
 
     private static void handleLoadoutCompletion(Minecraft client) {
@@ -260,7 +266,10 @@ public class LoadoutManager {
             loadoutInteractionStage = 0;
             loadoutOpenPendingTime = 0;
             loadoutFirstClickDelayMs = 0;
-            handleLoadoutCompletion(client);
+            ClientUtils.closeGuiAsync(client).thenRun(() -> {
+                loadoutGuiCloseComplete = true;
+                handleLoadoutCompletion(client);
+            });
         }
     }
 

--- a/src/main/java/dev/aether/modules/gear/helpers/LoadoutManager.java
+++ b/src/main/java/dev/aether/modules/gear/helpers/LoadoutManager.java
@@ -42,7 +42,7 @@ public class LoadoutManager {
     }
 
     public static void triggerLoadoutSwap(Minecraft client, int slot) {
-        if (trackedLoadoutSlot == slot) {
+        if (trackedLoadoutSlot == slot || (isSwappingLoadout && targetLoadoutSlot == slot)) {
             ClientUtils.sendDebugMessage("Loadout already on target slot, restarting farming");
             client.execute(() -> FarmingMacroManager.disable(client));
             MacroWorkerThread.getInstance().submit("Wardrobe-AlreadyOnSlot-FastResume", () -> {
@@ -99,7 +99,7 @@ public class LoadoutManager {
     }
 
     public static void ensureLoadoutSlot(Minecraft client, int slot) {
-        if (trackedLoadoutSlot == slot) {
+        if (slot <= 0 || trackedLoadoutSlot == slot || (isSwappingLoadout && targetLoadoutSlot == slot)) {
             return;
         }
         targetLoadoutSlot = slot;

--- a/src/main/java/dev/aether/modules/inventorymanager/AutoSellManager.java
+++ b/src/main/java/dev/aether/modules/inventorymanager/AutoSellManager.java
@@ -43,6 +43,7 @@ public class AutoSellManager {
     }
 
     public static void cancel(Minecraft client) {
+        boolean autoSellWasActive = isSelling || isPreparingToSell || isTriggeredBeforeVisitors;
         cancelRequested = true;
         isSelling = false;
         isPreparingToSell = false;
@@ -50,12 +51,8 @@ public class AutoSellManager {
         thresholdMetStartTime = 0;
         awaitingFirstGuiClick = false;
         interactionTime = 0;
-        if (client != null) {
-            client.execute(() -> {
-                if (client.player != null && client.screen != null) {
-                    client.player.closeContainer();
-                }
-            });
+        if (client != null && autoSellWasActive) {
+            ClientUtils.closeGui(client);
         }
     }
 
@@ -302,12 +299,7 @@ public class AutoSellManager {
                 isSelling = true;
                 interactionTime = System.currentTimeMillis();
                 awaitingFirstGuiClick = true;
-                client.execute(() -> {
-                    if (client.player != null && client.screen != null) {
-                        client.player.closeContainer();
-                    }
-                });
-                MacroWorkerThread.sleep(200);
+                ClientUtils.closeGui(client);
                 ClientUtils.sendCommand("/boostercookie");
 
                 while (isSelling && !shouldAbort()) {
@@ -472,9 +464,7 @@ public class AutoSellManager {
     }
 
     public static void finishSelling(Minecraft client) {
-        if (client.player != null && client.screen != null) {
-            client.player.closeContainer();
-        }
+        ClientUtils.closeGui(client);
         isSelling = false;
     }
 }

--- a/src/main/java/dev/aether/modules/pest/PestManager.java
+++ b/src/main/java/dev/aether/modules/pest/PestManager.java
@@ -517,10 +517,16 @@ public class PestManager {
     }
 
     public static void decrementPredictedAliveCount(Minecraft client) {
-        if (predictedAliveCount > 0) {
-            predictedAliveCount--;
+        decrementPredictedAliveCount(client, 1);
+    }
+
+    public static synchronized void decrementPredictedAliveCount(Minecraft client, int killedCount) {
+        int appliedKills = Math.min(predictedAliveCount, Math.max(0, killedCount));
+        if (appliedKills > 0) {
+            predictedAliveCount -= appliedKills;
             lastLocalKillUpdateMs = System.currentTimeMillis();
-            ClientUtils.sendDebugMessage("Pest kill detected! Predicted alive: " + predictedAliveCount
+            ClientUtils.sendDebugMessage("Pest kill detected! Count: " + appliedKills
+                            + ", predicted alive: " + predictedAliveCount
                             + ", currentPlot=" + ClientUtils.getCurrentPlot()
                             + ", whitelistedPlots=" + AetherConfig.LEAVE_ONE_PEST_PLOTS.get());
 

--- a/src/main/java/dev/aether/modules/pest/PestManager.java
+++ b/src/main/java/dev/aether/modules/pest/PestManager.java
@@ -274,7 +274,8 @@ public class PestManager {
             return;
         }
 
-        if (isThresholdMet(effectiveAlive)) {
+        Set<String> actionablePlots = PestDestroyer.filterRememberedLeaveOnePlots(data.infestedPlots());
+        if (isThresholdMet(effectiveAlive) && !actionablePlots.isEmpty()) {
             if (isPestReentryCooldownActive()) {
                 return;
             }
@@ -294,9 +295,9 @@ public class PestManager {
             if (effectiveAlive >= 8 && effectiveAlive < 99) {
                 ClientUtils.sendMessage("\u00A7eMax Pests (8) reached. Starting cleaning...", true);
             }
-            setCurrentInfestedPlots(data.infestedPlots());
-            String targetPlot = data.infestedPlots().stream().findFirst().orElse(null);
-            ClientUtils.sendDebugMessage("[PestManager] Tab threshold met. infestedPlots=" + data.infestedPlots()
+            setCurrentInfestedPlots(actionablePlots);
+            String targetPlot = actionablePlots.stream().findFirst().orElse(null);
+            ClientUtils.sendDebugMessage("[PestManager] Tab threshold met. infestedPlots=" + actionablePlots
                             + " targetPlot=" + targetPlot + " currentPlot=" + ClientUtils.getCurrentPlot());
             boolean started = startCleaningSequence(client, targetPlot, effectiveAlive);
             if (started) {
@@ -402,11 +403,13 @@ public class PestManager {
             return false;
         }
 
-        Set<String> candidatePlots = new LinkedHashSet<>(data.infestedPlots());
+        Set<String> candidatePlots = new LinkedHashSet<>();
         String normalizedRequestedPlot = PestPlotId.normalize(requestedPlot);
         if (PestPlotId.isUsable(normalizedRequestedPlot)) {
             candidatePlots.add(normalizedRequestedPlot);
         }
+        candidatePlots.addAll(data.infestedPlots());
+        candidatePlots = PestDestroyer.filterRememberedLeaveOnePlots(candidatePlots);
 
         String targetPlot = candidatePlots.stream()
                 .findFirst()

--- a/src/main/java/dev/aether/modules/pest/PestManager.java
+++ b/src/main/java/dev/aether/modules/pest/PestManager.java
@@ -38,6 +38,8 @@ public class PestManager {
     private static volatile boolean isCleaningTriggerPending = false;
     private static volatile long pestReentryCooldownUntilMs = 0;
     private static volatile PendingChatTrigger pendingChatTrigger;
+    private static volatile boolean pendingChatTriggerWaitsForLoadout = false;
+    private static volatile long pendingChatTriggerDelayAfterLoadoutMs = 0L;
     private static volatile int lastCleaningAliveCount = -1;
     private static volatile long lastCleaningProgressAtMs = 0L;
     private static volatile boolean rewarpTriggerAvailable = false;
@@ -177,6 +179,8 @@ public class PestManager {
         isCleaningTriggerPending = false;
         pestReentryCooldownUntilMs = 0;
         pendingChatTrigger = null;
+        pendingChatTriggerWaitsForLoadout = false;
+        pendingChatTriggerDelayAfterLoadoutMs = 0L;
         lastCleaningAliveCount = -1;
         lastCleaningProgressAtMs = 0L;
         rewarpTriggerAvailable = false;
@@ -335,21 +339,34 @@ public class PestManager {
 
     /** Schedules a chat trigger without blocking the shared worker or farming. */
     public static synchronized void scheduleChatCleaningTrigger(String plot, int spawnedCount, long delayMs) {
+        boolean requestedBallsackLoadout = false;
         if (AetherConfig.BALLSACK_SHREDDER.get()) {
             int farmingSlot = AetherConfig.LOADOUT_SLOT_FARMING.get();
-            if (farmingSlot > 0) {
-                if (LoadoutManager.trackedLoadoutSlot != farmingSlot
-                        && !(LoadoutManager.isSwappingLoadout && LoadoutManager.targetLoadoutSlot == farmingSlot)) {
-                    LoadoutManager.triggerLoadoutSwap(Minecraft.getInstance(), farmingSlot);
-                }
+            if (farmingSlot > 0
+                    && LoadoutManager.trackedLoadoutSlot != farmingSlot
+                    && !(LoadoutManager.isSwappingLoadout
+                            && LoadoutManager.targetLoadoutSlot == farmingSlot)) {
+                LoadoutManager.triggerLoadoutSwap(Minecraft.getInstance(), farmingSlot);
+                requestedBallsackLoadout = true;
             }
         }
-        long triggerAt = System.currentTimeMillis() + Math.max(0L, delayMs);
+
+        long normalizedDelayMs = Math.max(0L, delayMs);
+        long triggerAt = System.currentTimeMillis() + normalizedDelayMs;
         if (pendingChatTrigger == null) {
             pendingChatTrigger = new PendingChatTrigger(plot, Math.max(0, spawnedCount), triggerAt);
-            return;
+        } else {
+            pendingChatTrigger = new PendingChatTrigger(plot,
+                    pendingChatTrigger.spawnedCount + Math.max(0, spawnedCount),
+                    Math.min(pendingChatTrigger.triggerAtMs, triggerAt));
         }
-        pendingChatTrigger = new PendingChatTrigger(plot, pendingChatTrigger.spawnedCount + Math.max(0, spawnedCount), Math.min(pendingChatTrigger.triggerAtMs, triggerAt));
+
+        if (requestedBallsackLoadout) {
+            pendingChatTriggerWaitsForLoadout = true;
+            pendingChatTriggerDelayAfterLoadoutMs = pendingChatTriggerDelayAfterLoadoutMs == 0L
+                    ? normalizedDelayMs
+                    : Math.min(pendingChatTriggerDelayAfterLoadoutMs, normalizedDelayMs);
+        }
     }
 
     private static synchronized boolean processPendingChatTrigger(Minecraft client, MacroState.State currentState) {
@@ -357,11 +374,26 @@ public class PestManager {
         if (pending == null) {
             return false;
         }
+        if (pendingChatTriggerWaitsForLoadout) {
+            if (LoadoutManager.isSwappingLoadout
+                    || !LoadoutManager.loadoutGuiCloseComplete
+                    || currentState != MacroState.State.FARMING) {
+                return false;
+            }
+
+            pendingChatTrigger = new PendingChatTrigger(pending.plot, pending.spawnedCount,
+                    System.currentTimeMillis() + pendingChatTriggerDelayAfterLoadoutMs);
+            pendingChatTriggerWaitsForLoadout = false;
+            pendingChatTriggerDelayAfterLoadoutMs = 0L;
+            return false;
+        }
         if (currentState != MacroState.State.FARMING) {
             if (AetherConfig.BALLSACK_SHREDDER.get() && LoadoutManager.isSwappingLoadout) {
                 return false;
             }
             pendingChatTrigger = null;
+            pendingChatTriggerWaitsForLoadout = false;
+            pendingChatTriggerDelayAfterLoadoutMs = 0L;
             return false;
         }
         if (System.currentTimeMillis() < pending.triggerAtMs) {
@@ -371,6 +403,8 @@ public class PestManager {
             return false;
         }
         pendingChatTrigger = null;
+        pendingChatTriggerWaitsForLoadout = false;
+        pendingChatTriggerDelayAfterLoadoutMs = 0L;
         tryStartCleaningSequenceFromChat(client, pending.plot, pending.spawnedCount);
         return true;
     }

--- a/src/main/java/dev/aether/modules/pest/PestManager.java
+++ b/src/main/java/dev/aether/modules/pest/PestManager.java
@@ -37,6 +37,7 @@ public class PestManager {
     private static volatile long lastLocalKillUpdateMs = 0;
     private static volatile boolean isCleaningTriggerPending = false;
     private static volatile long pestReentryCooldownUntilMs = 0;
+    private static volatile PendingChatTrigger pendingChatTrigger;
     private static volatile int lastCleaningAliveCount = -1;
     private static volatile long lastCleaningProgressAtMs = 0L;
     private static volatile boolean rewarpTriggerAvailable = false;
@@ -175,6 +176,7 @@ public class PestManager {
         lastLocalKillUpdateMs = 0;
         isCleaningTriggerPending = false;
         pestReentryCooldownUntilMs = 0;
+        pendingChatTrigger = null;
         lastCleaningAliveCount = -1;
         lastCleaningProgressAtMs = 0L;
         rewarpTriggerAvailable = false;
@@ -199,6 +201,16 @@ public class PestManager {
             return;
         if (!isPestDestroyerEnabled())
             return;
+
+        if (processPendingChatTrigger(client, currentState)) {
+            return;
+        }
+
+        // A delayed chat trigger owns this pest event. Tab-list updates may refresh
+        // the count, but must not start cleaning before the full delay expires.
+        if (pendingChatTrigger != null) {
+            return;
+        }
 
         if (isCleaningInProgress
                 && currentState == MacroState.State.FARMING
@@ -320,6 +332,35 @@ public class PestManager {
         Minecraft client = Minecraft.getInstance();
         checkTabListForPests(client, MacroStateManager.getCurrentState());
     }
+
+    /** Schedules a chat trigger without blocking the shared worker or farming. */
+    public static synchronized void scheduleChatCleaningTrigger(String plot, int spawnedCount, long delayMs) {
+        long triggerAt = System.currentTimeMillis() + Math.max(0L, delayMs);
+        if (pendingChatTrigger == null) {
+            pendingChatTrigger = new PendingChatTrigger(plot, Math.max(0, spawnedCount), triggerAt);
+            return;
+        }
+        pendingChatTrigger = new PendingChatTrigger(plot, pendingChatTrigger.spawnedCount + Math.max(0, spawnedCount), Math.min(pendingChatTrigger.triggerAtMs, triggerAt));
+    }
+
+    private static synchronized boolean processPendingChatTrigger(Minecraft client, MacroState.State currentState) {
+        PendingChatTrigger pending = pendingChatTrigger;
+        if (pending == null) {
+            return false;
+        }
+        if (currentState != MacroState.State.FARMING) {
+            pendingChatTrigger = null;
+            return false;
+        }
+        if (System.currentTimeMillis() < pending.triggerAtMs) {
+            return false;
+        }
+        pendingChatTrigger = null;
+        tryStartCleaningSequenceFromChat(client, pending.plot, pending.spawnedCount);
+        return true;
+    }
+
+    private record PendingChatTrigger(String plot, int spawnedCount, long triggerAtMs) {}
 
     /**
      * Returns effective pests alive count from tab/chat sync.

--- a/src/main/java/dev/aether/modules/pest/PestManager.java
+++ b/src/main/java/dev/aether/modules/pest/PestManager.java
@@ -335,6 +335,15 @@ public class PestManager {
 
     /** Schedules a chat trigger without blocking the shared worker or farming. */
     public static synchronized void scheduleChatCleaningTrigger(String plot, int spawnedCount, long delayMs) {
+        if (AetherConfig.BALLSACK_SHREDDER.get()) {
+            int farmingSlot = AetherConfig.LOADOUT_SLOT_FARMING.get();
+            if (farmingSlot > 0) {
+                if (LoadoutManager.trackedLoadoutSlot != farmingSlot
+                        && !(LoadoutManager.isSwappingLoadout && LoadoutManager.targetLoadoutSlot == farmingSlot)) {
+                    LoadoutManager.triggerLoadoutSwap(Minecraft.getInstance(), farmingSlot);
+                }
+            }
+        }
         long triggerAt = System.currentTimeMillis() + Math.max(0L, delayMs);
         if (pendingChatTrigger == null) {
             pendingChatTrigger = new PendingChatTrigger(plot, Math.max(0, spawnedCount), triggerAt);
@@ -349,10 +358,16 @@ public class PestManager {
             return false;
         }
         if (currentState != MacroState.State.FARMING) {
+            if (AetherConfig.BALLSACK_SHREDDER.get() && LoadoutManager.isSwappingLoadout) {
+                return false;
+            }
             pendingChatTrigger = null;
             return false;
         }
         if (System.currentTimeMillis() < pending.triggerAtMs) {
+            return false;
+        }
+        if (LoadoutManager.isSwappingLoadout || !MacroStateManager.isMacroRunning()) {
             return false;
         }
         pendingChatTrigger = null;

--- a/src/main/java/dev/aether/modules/pest/helpers/PestAotvManager.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestAotvManager.java
@@ -10,6 +10,7 @@ import net.minecraft.world.phys.Vec3;
 import dev.aether.modules.gear.GearManager;
 import dev.aether.macro.MacroWorkerThread;
 import dev.aether.modules.rotation.RotationManager;
+import dev.aether.modules.failsafe.FailsafeManager;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -100,7 +101,7 @@ public class PestAotvManager {
     }
 
     public static boolean shouldDoAotvOnCurrentPlot(Minecraft client, String currentInfestedPlot, boolean isSamePlot) {
-        if (!AetherConfig.AOTV_TO_ROOF.get())
+        if (AetherConfig.BALLSACK_SHREDDER.get() || !AetherConfig.AOTV_TO_ROOF.get())
             return false;
 
         if (AetherConfig.AOTV_ROOF_PLOTS.get().isEmpty())
@@ -255,7 +256,9 @@ public class PestAotvManager {
 
         float targetYaw = PestClientThread.call(
                 client, () -> client.player.getYRot() + randomYawOffset(), 0.0f);
-        float targetPitch = (float) (-30.0 + Math.random() * 60.0);
+        float targetPitch = AetherConfig.BALLSACK_SHREDDER.get()
+                ? 90.0f
+                : (float) (-30.0 + Math.random() * 60.0);
         int rotTime = (int) (AetherConfig.ROTATION_TIME.get() * (0.92 + Math.random() * 0.16));
         AtomicBoolean started = new AtomicBoolean(false);
         client.execute(() -> {
@@ -272,6 +275,16 @@ public class PestAotvManager {
         }
         while (started.get() && RotationManager.isRotating() && System.currentTimeMillis() < deadline) {
             MacroWorkerThread.sleep(20);
+        }
+
+        if (AetherConfig.BALLSACK_SHREDDER.get()) {
+            int vacuumSlot = PestLoadoutHelper.findVacuumHotbarSlot(client);
+            if (vacuumSlot >= 0 && vacuumSlot < 9) {
+                PestClientThread.run(client, () -> {
+                    FailsafeManager.selectHotbarSlot(client, vacuumSlot);
+                    ClientUtils.setKeyMappingState(client.options.keyUse, true);
+                });
+            }
         }
     }
 

--- a/src/main/java/dev/aether/modules/pest/helpers/PestAotvManager.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestAotvManager.java
@@ -192,12 +192,12 @@ public class PestAotvManager {
             return;
         }
         Vec3 eyePos = aimOrigin.eyePosition();
-        float upwardYaw = aimOrigin.yaw() + randomYawOffset();
+        float upwardYaw = aimOrigin.yaw();
         float yawRad = (float) Math.toRadians(upwardYaw);
-        int baseUpPitch = Math.max(20, Math.min(90, AetherConfig.AOTV_ROOF_PITCH.get()));
+        int baseUpPitch = Math.max(0, Math.min(90, AetherConfig.AOTV_ROOF_PITCH.get()));
         int humanization = Math.max(0, Math.min(15, AetherConfig.AOTV_ROOF_PITCH_HUMANIZATION.get()));
         double randomizedUpPitch = baseUpPitch + ((Math.random() * 2.0) - 1.0) * humanization;
-        randomizedUpPitch = Math.max(20.0, Math.min(90.0, randomizedUpPitch));
+        randomizedUpPitch = Math.max(0.0, Math.min(90.0, randomizedUpPitch));
         float targetMcPitch = (float) -randomizedUpPitch;
         double pitchRad = Math.toRadians(targetMcPitch);
 

--- a/src/main/java/dev/aether/modules/pest/helpers/PestBallsackShredder.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestBallsackShredder.java
@@ -1,0 +1,109 @@
+package dev.aether.modules.pest.helpers;
+
+import dev.aether.config.AetherConfig;
+import dev.aether.macro.MacroWorkerThread;
+import dev.aether.modules.failsafe.FailsafeManager;
+import dev.aether.modules.gear.GearManager;
+import dev.aether.modules.pest.PestManager;
+import dev.aether.modules.rotation.RotationManager;
+import dev.aether.util.ClientUtils;
+import net.minecraft.client.Minecraft;
+import net.minecraft.world.phys.Vec3;
+
+/** Dedicated pre-cleaning AOTV route used by Ballsack Shredder. */
+final class PestBallsackShredder {
+    private static final long AOTV_TIMEOUT_MS = 10_000L;
+    private static final double POSITION_CHANGE_DISTANCE_SQR = 1.0;
+
+    private PestBallsackShredder() {
+    }
+
+    static boolean run(Minecraft client, int sessionId) throws InterruptedException {
+        if (client == null || client.player == null || client.options == null) {
+            return false;
+        }
+
+        int aotvSlot = GearManager.findAspectOfTheVoidSlot(client);
+        if (aotvSlot < 0 || aotvSlot >= 9) {
+            ClientUtils.sendDebugMessage("Ballsack Shredder: no AOTV found; continuing without the route.");
+            return true;
+        }
+
+        // This route intentionally preserves the current aim while firing the AOTV.
+        GearManager.swapToAOTVSync(client);
+        PestClientThread.run(client, () -> {
+            ClientUtils.setKeyMappingState(client.options.keyShift, true);
+            ClientUtils.setKeyMappingState(client.options.keyUse, true);
+        });
+
+        int positionChanges = waitForPositionChanges(client, sessionId);
+        releaseAotvKeys(client);
+        if (shouldAbort(client, sessionId)) {
+            return false;
+        }
+        if (positionChanges < 2) {
+            ClientUtils.sendDebugMessage("Ballsack Shredder: AOTV timed out after "
+                    + positionChanges + " position change(s); continuing pest cleaning.");
+            return true;
+        }
+
+        lookDownAndHoldVacuum(client, sessionId);
+        return !shouldAbort(client, sessionId);
+    }
+
+    private static int waitForPositionChanges(Minecraft client, int sessionId) throws InterruptedException {
+        Vec3 lastPosition = PestClientThread.call(client, () -> client.player.position(), null);
+        if (lastPosition == null) {
+            return 0;
+        }
+
+        int changes = 0;
+        long deadline = System.currentTimeMillis() + AOTV_TIMEOUT_MS;
+        while (changes < 2 && System.currentTimeMillis() < deadline && !shouldAbort(client, sessionId)) {
+            MacroWorkerThread.sleep(25);
+            Vec3 previousPosition = lastPosition;
+            Vec3 currentPosition = PestClientThread.call(client, () -> client.player.position(), previousPosition);
+            if (currentPosition.distanceToSqr(previousPosition) >= POSITION_CHANGE_DISTANCE_SQR) {
+                changes++;
+                lastPosition = currentPosition;
+            }
+        }
+        return changes;
+    }
+
+    private static void lookDownAndHoldVacuum(Minecraft client, int sessionId) throws InterruptedException {
+        PestClientThread.run(client, () -> RotationManager.rotateToYawPitch(
+                client, client.player.getYRot(), 90.0f, AetherConfig.ROTATION_TIME.get(), true));
+        long rotationDeadline = System.currentTimeMillis() + AetherConfig.ROTATION_TIME.get() + 1_000L;
+        while (RotationManager.isRotating() && System.currentTimeMillis() < rotationDeadline
+                && !shouldAbort(client, sessionId)) {
+            MacroWorkerThread.sleep(20);
+        }
+
+        int vacuumSlot = PestLoadoutHelper.findVacuumHotbarSlot(client);
+        if (vacuumSlot < 0 || vacuumSlot >= 9) {
+            return;
+        }
+        PestClientThread.run(client, () -> {
+            FailsafeManager.selectHotbarSlot(client, vacuumSlot);
+            ClientUtils.setKeyMappingState(client.options.keyUse, true);
+        });
+        long holdUntil = System.currentTimeMillis() + AetherConfig.BALLSACK_LOOK_DOWN_TIME_MS.get();
+        while (System.currentTimeMillis() < holdUntil && !shouldAbort(client, sessionId)) {
+            MacroWorkerThread.sleep(20);
+        }
+    }
+
+    private static void releaseAotvKeys(Minecraft client) {
+        PestClientThread.run(client, () -> {
+            ClientUtils.setKeyMappingState(client.options.keyShift, false);
+            ClientUtils.setKeyMappingState(client.options.keyUse, false);
+        });
+    }
+
+    private static boolean shouldAbort(Minecraft client, int sessionId) {
+        return MacroWorkerThread.shouldAbortTask(client)
+                || sessionId != PestManager.getCurrentPestSessionId()
+                || !PestManager.isCleaningInProgress();
+    }
+}

--- a/src/main/java/dev/aether/modules/pest/helpers/PestBallsackShredder.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestBallsackShredder.java
@@ -8,25 +8,36 @@ import dev.aether.modules.pest.PestManager;
 import dev.aether.modules.rotation.RotationManager;
 import dev.aether.util.ClientUtils;
 import net.minecraft.client.Minecraft;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.phys.Vec3;
+
+import java.util.List;
 
 /** Dedicated pre-cleaning AOTV route used by Ballsack Shredder. */
 final class PestBallsackShredder {
     private static final long AOTV_TIMEOUT_MS = 10_000L;
+    private static final long RESULT_CONFIRM_TIMEOUT_MS = 2_000L;
     private static final double POSITION_CHANGE_DISTANCE_SQR = 1.0;
 
     private PestBallsackShredder() {
     }
 
-    static boolean run(Minecraft client, int sessionId) throws InterruptedException {
+    record Result(boolean successful, boolean measured, int estimatedKilled, int estimatedRemaining) {
+        static Result unmeasured(boolean successful, int startingPests) {
+            return new Result(successful, false, 0, Math.max(0, startingPests));
+        }
+    }
+
+    static Result run(Minecraft client, int sessionId, int startingPests) throws InterruptedException {
         if (client == null || client.player == null || client.options == null) {
-            return false;
+            return Result.unmeasured(false, startingPests);
         }
 
         int aotvSlot = GearManager.findAspectOfTheVoidSlot(client);
         if (aotvSlot < 0 || aotvSlot >= 9) {
             ClientUtils.sendDebugMessage("Ballsack Shredder: no AOTV found; continuing without the route.");
-            return true;
+            return Result.unmeasured(true, startingPests);
         }
 
         // This route intentionally preserves the current aim while firing the AOTV.
@@ -39,16 +50,84 @@ final class PestBallsackShredder {
         int positionChanges = waitForPositionChanges(client, sessionId);
         releaseAotvKeys(client);
         if (shouldAbort(client, sessionId)) {
-            return false;
+            return Result.unmeasured(false, startingPests);
         }
         if (positionChanges < 2) {
             ClientUtils.sendDebugMessage("Ballsack Shredder: AOTV timed out after "
                     + positionChanges + " position change(s); continuing pest cleaning.");
-            return true;
+            return Result.unmeasured(true, startingPests);
         }
 
-        lookDownAndHoldVacuum(client, sessionId);
-        return !shouldAbort(client, sessionId);
+        List<Entity> trackedPests = PestClientThread.call(
+                client,
+                () -> List.copyOf(PestTargetTracker.getLoadedPests(client)),
+                List.of());
+        if (!lookDownAndHoldVacuum(client, sessionId)) {
+            return Result.unmeasured(!shouldAbort(client, sessionId), startingPests);
+        }
+        if (shouldAbort(client, sessionId)) {
+            return Result.unmeasured(false, startingPests);
+        }
+
+        releaseVacuumUse(client);
+        Result result = awaitResultEvidence(
+                client, sessionId, startingPests, trackedPests);
+        int trackedKills = countTrackedKills(trackedPests);
+        int tabRemaining = PestClientThread.call(
+                client,
+                () -> PestManager.getTabAliveCountNow(client),
+                -1);
+        ClientUtils.sendDebugMessage("Ballsack Shredder: estimated killed="
+                + result.estimatedKilled() + ", remaining=" + result.estimatedRemaining()
+                + " (start=" + Math.max(0, startingPests)
+                + ", tracked removals=" + trackedKills
+                + ", tab remaining=" + tabRemaining + ").");
+        return result;
+    }
+
+    private static Result awaitResultEvidence(
+            Minecraft client,
+            int sessionId,
+            int startingPests,
+            List<Entity> trackedPests) throws InterruptedException {
+        Result latest = estimateResult(startingPests, countTrackedKills(trackedPests),
+                PestClientThread.call(client, () -> PestManager.getTabAliveCountNow(client), -1));
+        if (latest.estimatedRemaining() <= 1) {
+            return latest;
+        }
+
+        long deadline = System.currentTimeMillis() + RESULT_CONFIRM_TIMEOUT_MS;
+
+        while (System.currentTimeMillis() < deadline && !shouldAbort(client, sessionId)) {
+            int trackedKills = countTrackedKills(trackedPests);
+            int tabRemaining = PestClientThread.call(
+                    client,
+                    () -> PestManager.getTabAliveCountNow(client),
+                    -1);
+            latest = estimateResult(startingPests, trackedKills, tabRemaining);
+            if (latest.estimatedRemaining() <= 1) {
+                return latest;
+            }
+
+            MacroWorkerThread.sleep(50);
+        }
+        return latest;
+    }
+
+    private static int countTrackedKills(List<Entity> trackedPests) {
+        return (int) trackedPests.stream()
+                .filter(PestBallsackShredder::isDead)
+                .count();
+    }
+
+    static Result estimateResult(int startingPests, int trackedKills, int tabRemaining) {
+        int normalizedStart = Math.max(0, startingPests);
+        int killsFromEntities = Math.min(normalizedStart, Math.max(0, trackedKills));
+        int killsFromTab = tabRemaining < 0
+                ? normalizedStart
+                : Math.max(0, normalizedStart - tabRemaining);
+        int estimatedKilled = Math.max(killsFromEntities, killsFromTab);
+        return new Result(true, true, estimatedKilled, normalizedStart - estimatedKilled);
     }
 
     private static int waitForPositionChanges(Minecraft client, int sessionId) throws InterruptedException {
@@ -71,7 +150,7 @@ final class PestBallsackShredder {
         return changes;
     }
 
-    private static void lookDownAndHoldVacuum(Minecraft client, int sessionId) throws InterruptedException {
+    private static boolean lookDownAndHoldVacuum(Minecraft client, int sessionId) throws InterruptedException {
         PestClientThread.run(client, () -> RotationManager.rotateToYawPitch(
                 client, client.player.getYRot(), 90.0f, AetherConfig.ROTATION_TIME.get(), true));
         long rotationDeadline = System.currentTimeMillis() + AetherConfig.ROTATION_TIME.get() + 1_000L;
@@ -82,7 +161,8 @@ final class PestBallsackShredder {
 
         int vacuumSlot = PestLoadoutHelper.findVacuumHotbarSlot(client);
         if (vacuumSlot < 0 || vacuumSlot >= 9) {
-            return;
+            ClientUtils.sendDebugMessage("Ballsack Shredder: no vacuum found for lookdown; continuing pest cleaning.");
+            return false;
         }
         PestClientThread.run(client, () -> {
             FailsafeManager.selectHotbarSlot(client, vacuumSlot);
@@ -92,6 +172,12 @@ final class PestBallsackShredder {
         while (System.currentTimeMillis() < holdUntil && !shouldAbort(client, sessionId)) {
             MacroWorkerThread.sleep(20);
         }
+        return true;
+    }
+
+    private static boolean isDead(Entity entity) {
+        return entity.isRemoved()
+                || entity instanceof LivingEntity living && living.isDeadOrDying();
     }
 
     private static void releaseAotvKeys(Minecraft client) {
@@ -99,6 +185,11 @@ final class PestBallsackShredder {
             ClientUtils.setKeyMappingState(client.options.keyShift, false);
             ClientUtils.setKeyMappingState(client.options.keyUse, false);
         });
+    }
+
+    private static void releaseVacuumUse(Minecraft client) {
+        PestClientThread.run(client, () ->
+                ClientUtils.setKeyMappingState(client.options.keyUse, false));
     }
 
     private static boolean shouldAbort(Minecraft client, int sessionId) {

--- a/src/main/java/dev/aether/modules/pest/helpers/PestCombatCoordinator.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestCombatCoordinator.java
@@ -189,7 +189,9 @@ final class PestCombatCoordinator {
         if (currentTarget == null || currentTarget.isRemoved() || (currentTarget instanceof LivingEntity le && le.isDeadOrDying())) {
             ClientUtils.setKeyMappingState(client.options.keyUse, false);
             if (currentTarget != null && (currentTarget.isRemoved() || (currentTarget instanceof LivingEntity le2 && le2.isDeadOrDying()))) {
-                context.recordTrackedPestKill(client, currentTarget);
+                if (context.recordTrackedPestKill(client, currentTarget)) {
+                    return;
+                }
             }
             context.setState(PestDestroyer.State.CHECK_NEXT);
             return;
@@ -255,7 +257,9 @@ final class PestCombatCoordinator {
                     ClientUtils.setKeyMappingState(client.options.keyUse, false);
                     ClientUtils.setKeyMappingState(client.options.keyDown, false);
                     context.markKilled(currentTarget);
-                    context.recordTrackedPestKill(client, currentTarget);
+                    if (context.recordTrackedPestKill(client, currentTarget)) {
+                        return;
+                    }
                     ClientUtils.sendDebugMessage("[PestDestroyer] Pest skull disappeared. Switching target immediately.");
                     if (!context.switchToNextQueuedTarget(client)) {
                         context.setState(PestDestroyer.State.CHECK_NEXT);

--- a/src/main/java/dev/aether/modules/pest/helpers/PestDestroyer.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestDestroyer.java
@@ -199,6 +199,11 @@ public class PestDestroyer {
             return;
         }
 
+        if (PestTargetController.reconcileTrackedKills(
+                client, runtime, CONTEXT)) {
+            return;
+        }
+
         if (PestDestroyerProgressController.tick(
                 client, runtime, STUCK_TIMEOUT_MS, CONTEXT)) {
             return;

--- a/src/main/java/dev/aether/modules/pest/helpers/PestDestroyer.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestDestroyer.java
@@ -92,6 +92,7 @@ public class PestDestroyer {
             // Fallback to cached value
             infested = PestManager.getCurrentInfestedPlots();
         }
+        infested = PestLeaveOneController.filterSkippedPlots(runtime, infested);
 
         if (PestPlotId.isUsable(initialPlot)) {
             runtime.navigation.plotQueue.add(initialPlot);
@@ -165,6 +166,7 @@ public class PestDestroyer {
     }
 
     public static void reset() {
+        PestLeaveOneController.clearRememberedPlots(runtime);
         runtime.resetAll();
     }
 
@@ -469,6 +471,18 @@ public class PestDestroyer {
 
     static Set<String> filterSkippedInfestedPlots(Set<String> infested) {
         return PestLeaveOneController.filterSkippedPlots(runtime, infested);
+    }
+
+    public static Set<String> filterRememberedLeaveOnePlots(Set<String> infested) {
+        return PestLeaveOneController.filterSkippedPlots(runtime, infested);
+    }
+
+    public static void onPestsSpawnedInPlot(String plot) {
+        PestLeaveOneController.forgetPlot(runtime, plot);
+    }
+
+    public static void clearRememberedLeaveOnePlots() {
+        PestLeaveOneController.clearRememberedPlots(runtime);
     }
 
     private static boolean plotsEqual(String first, String second) {

--- a/src/main/java/dev/aether/modules/pest/helpers/PestDestroyer.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestDestroyer.java
@@ -48,6 +48,7 @@ public class PestDestroyer {
         AOTV_BETWEEN_PESTS,
         AOTV_TO_ROOF,
         AOTV_TO_ROOF_RETURN,
+        AOTV_POST_LOOKDOWN,
         FINISH
     }
 
@@ -214,6 +215,7 @@ public class PestDestroyer {
                     || runtime.state == State.TELEPORT_TO_PLOT
                     || runtime.state == State.AOTV_TO_ROOF
                     || runtime.state == State.AOTV_TO_ROOF_RETURN
+                    || runtime.state == State.AOTV_POST_LOOKDOWN
                     || runtime.state == State.FLY_UP) {
                 break;
             }
@@ -243,6 +245,7 @@ public class PestDestroyer {
             } // Handled by worker thread
             case AOTV_TO_ROOF_RETURN -> {
             } // Handled early in update()
+            case AOTV_POST_LOOKDOWN -> handlePostAotvLookdown(client);
             case FINISH -> finish(client);
             default -> {
             }
@@ -308,6 +311,11 @@ public class PestDestroyer {
         State returnState = runtime.roofAotvReturnState;
         runtime.roofAotvReturnState = null;
         if (!runtime.active) {
+            return;
+        }
+        if (runtime.state == State.AOTV_POST_LOOKDOWN) {
+            runtime.roofAotvReturnState = null;
+            setState(State.FLY_UP);
             return;
         }
         if (returnState == null || returnState == State.IDLE || returnState == State.FINISH
@@ -402,6 +410,25 @@ public class PestDestroyer {
                 CONTEXT,
                 PATHFINDER_STUCK_RETRY_TICKS,
                 STATE_TIMEOUT_MS);
+    }
+
+    private static void handlePostAotvLookdown(Minecraft client) {
+        if (RotationManager.isRotating()) {
+            return;
+        }
+        if (runtime.vacuumSlot < 0) {
+            setState(State.EQUIP_VACUUM);
+            return;
+        }
+        int selected = ((dev.aether.mixin.AccessorInventory) client.player.getInventory()).getSelected();
+        if (selected != runtime.vacuumSlot) {
+            client.execute(() -> FailsafeManager.selectHotbarSlot(client, runtime.vacuumSlot));
+            return;
+        }
+        ClientUtils.setKeyMappingState(client.options.keyUse, true);
+        if (System.currentTimeMillis() - runtime.stateEnteredAt >= AetherConfig.BALLSACK_LOOK_DOWN_TIME_MS.get()) {
+            completeRoofAotv();
+        }
     }
 
     private static void handleAotvBetweenPests(Minecraft client) {

--- a/src/main/java/dev/aether/modules/pest/helpers/PestDestroyerCoordinatorContext.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestDestroyerCoordinatorContext.java
@@ -17,8 +17,7 @@ final class PestDestroyerCoordinatorContext
                 PestHuntController.Context,
                 PestNavigationCoordinator.Context,
                 PestCombatCoordinator.Context,
-                PestDestroyerProgressController.Context,
-                PestLeaveOneController.Context {
+                PestDestroyerProgressController.Context {
     private final PestDestroyerRuntime runtime;
 
     PestDestroyerCoordinatorContext(PestDestroyerRuntime runtime) {
@@ -97,7 +96,7 @@ final class PestDestroyerCoordinatorContext
 
     @Override
     public Entity findClosestPest(Minecraft client) {
-        return PestTargetController.findClosestPest(client, runtime);
+        return PestTargetController.findClosestPest(client, runtime, this);
     }
 
     @Override
@@ -108,11 +107,6 @@ final class PestDestroyerCoordinatorContext
     @Override
     public int countVisiblePestSkulls(Minecraft client) {
         return PestTargetController.countVisiblePestSkulls(client);
-    }
-
-    @Override
-    public int countAvailablePests(Minecraft client) {
-        return PestTargetController.countAvailablePests(client, runtime);
     }
 
     @Override

--- a/src/main/java/dev/aether/modules/pest/helpers/PestDestroyerProgressController.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestDestroyerProgressController.java
@@ -72,7 +72,9 @@ final class PestDestroyerProgressController {
             if (!infested.isEmpty()) {
                 String firstPlot = infested.iterator().next();
                 String currentPlot = context.getEffectivePlot(client);
-                if (!context.plotsEqual(firstPlot, currentPlot)
+                boolean currentStillActionable = infested.stream()
+                        .anyMatch(plot -> context.plotsEqual(plot, currentPlot));
+                if (!currentStillActionable
                         && isImmediatePlotExitState(runtime.state)) {
                     ClientUtils.sendDebugMessage(
                             "[PestDestroyer] Plot "

--- a/src/main/java/dev/aether/modules/pest/helpers/PestDestroyerRuntime.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestDestroyerRuntime.java
@@ -119,6 +119,10 @@ final class PestDestroyerRuntime {
         killVacuumReleaseUntil = 0L;
     }
 
+    boolean claimKilledPestEntityId(int entityId) {
+        return accountedKilledPestEntityIds.add(entityId);
+    }
+
     private void resetTransientState() {
         stuckTicks = 0;
         approachTicks = 0;

--- a/src/main/java/dev/aether/modules/pest/helpers/PestHuntController.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestHuntController.java
@@ -37,7 +37,7 @@ final class PestHuntController {
 
         Entity pest = PestTargetController.nextQueuedPest(client, runtime);
         if (pest == null) {
-            PestTargetController.rebuildQueue(client, runtime);
+            PestTargetController.rebuildQueue(client, runtime, targetContext);
             pest = PestTargetController.nextQueuedPest(client, runtime);
         }
         if (pest != null) {
@@ -69,10 +69,16 @@ final class PestHuntController {
         }
 
         runtime.navigation.plotQueue.clear();
-        runtime.navigation.plotQueue.addAll(infested);
-        String firstPlot = runtime.navigation.plotQueue.getFirst();
         String currentPlot =
                 PestPlotNavigator.getEffectivePlot(client, runtime.navigation);
+        infested.stream()
+                .filter(plot -> PestPlotId.equals(plot, currentPlot))
+                .findFirst()
+                .ifPresent(runtime.navigation.plotQueue::add);
+        infested.stream()
+                .filter(plot -> !PestPlotId.equals(plot, currentPlot))
+                .forEach(runtime.navigation.plotQueue::add);
+        String firstPlot = runtime.navigation.plotQueue.getFirst();
 
         if (!PestPlotId.equals(firstPlot, currentPlot)) {
             runtime.navigation.currentPlotIdx = 0;

--- a/src/main/java/dev/aether/modules/pest/helpers/PestLeaveOneController.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestLeaveOneController.java
@@ -7,16 +7,18 @@ import dev.aether.util.ClientUtils;
 import net.minecraft.client.Minecraft;
 
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /** Encapsulates the optional "leave one pest alive" plot policy. */
 final class PestLeaveOneController {
+    private static final Pattern PLOT_PEST_COUNT =
+            Pattern.compile("(?i)\\bplot\\s*[-:#]?\\s*(\\d+)\\D+?x\\s*(\\d+)\\b");
+
     interface Context {
         String getEffectivePlot(Minecraft client);
-
-        int countAvailablePests(Minecraft client);
-
-        int countVisiblePestSkulls(Minecraft client);
 
         void setState(PestDestroyer.State state);
     }
@@ -32,25 +34,16 @@ final class PestLeaveOneController {
             return false;
         }
         if (aliveCount == 0) {
+            runtime.navigation.leaveOneSkippedPlots.clear();
             return true;
         }
         if (!AetherConfig.LEAVE_ONE_PEST_ALIVE.get()) {
+            resetTracking(runtime);
             return false;
         }
-
-        Set<String> leaveOnePlots =
-                new LinkedHashSet<>(runtime.navigation.leaveOneSkippedPlots);
-        for (String plot : PestManager.getInfestedPlotsFromTab(client)) {
-            String normalized = PestPlotId.normalize(plot);
-            if (runtime.navigation.leaveOneSkippedPlots.contains(normalized)) {
-                continue;
-            }
-            if (!isWhitelistedPlot(plot)) {
-                return false;
-            }
-            leaveOnePlots.add(normalized);
-        }
-        return !leaveOnePlots.isEmpty() && aliveCount <= leaveOnePlots.size();
+        pruneRememberedPlots(runtime);
+        return shouldFinishForCounts(
+                aliveCount, runtime.navigation.leaveOneSkippedPlots.size());
     }
 
     static boolean tryLeaveCurrentPlot(
@@ -63,6 +56,7 @@ final class PestLeaveOneController {
 
         String currentPlot = context.getEffectivePlot(client);
         if (!isWhitelistedPlot(currentPlot)) {
+            resetTracking(runtime);
             return false;
         }
 
@@ -71,32 +65,64 @@ final class PestLeaveOneController {
             return false;
         }
 
-        int localPests = Math.max(
-                context.countAvailablePests(client),
-                context.countVisiblePestSkulls(client));
-        int aliveNow = PestManager.getEffectiveAliveCountNow(client);
-        boolean hasLocalEvidence = localPests > 0 || !runtime.killedEntities.isEmpty();
-        boolean shouldSkip = localPests == 1
-                || (aliveNow == 1
-                        && hasOnlyCurrentActivePlot(client, runtime, currentPlot)
-                        && (hasLocalEvidence
-                                || PestCompletionGuard.isStartupGraceElapsed(runtime.activatedAt)));
-        if (!shouldSkip) {
-            return false;
+        int plotPests = parsePlotPestCount(ClientUtils.getSidebarLines(), currentPlot);
+        if (!normalized.equals(runtime.navigation.leaveOneTrackedPlot)) {
+            runtime.navigation.leaveOneTrackedPlot = normalized;
+            runtime.navigation.leaveOneRemainingKills = -1;
+            runtime.navigation.leaveOneUnbudgetedKills = 0;
+            runtime.navigation.leaveOneReservedEntityId = -1;
+        }
+        if (runtime.navigation.leaveOneRemainingKills < 0 && plotPests > 0) {
+            runtime.navigation.leaveOneRemainingKills = remainingKillBudget(
+                    plotPests, runtime.navigation.leaveOneUnbudgetedKills);
+            ClientUtils.sendDebugMessage(
+                    "PestDestroyer: Plot "
+                            + currentPlot
+                            + " leave-one kill budget is "
+                            + runtime.navigation.leaveOneRemainingKills
+                            + " after "
+                            + runtime.navigation.leaveOneUnbudgetedKills
+                            + " early kill(s).");
         }
 
-        runtime.navigation.leaveOneSkippedPlots.add(normalized);
-        ClientUtils.sendDebugMessage(
-                "PestDestroyer: leaving one pest alive on whitelisted plot "
-                        + currentPlot
-                        + ".");
-        moveToNextActivePlotOrFinish(client, runtime, context);
-        return true;
+        return (plotPests == 1 || runtime.navigation.leaveOneRemainingKills == 0)
+                && finishCurrentPlot(client, runtime, context, currentPlot);
+    }
+
+    static boolean recordTrackedKill(
+            Minecraft client,
+            PestDestroyerRuntime runtime,
+            Context context) {
+        String currentPlot = context.getEffectivePlot(client);
+        if (!isWhitelistedPlot(currentPlot)) {
+            return false;
+        }
+        String normalized = PestPlotId.normalize(currentPlot);
+        if (!normalized.equals(runtime.navigation.leaveOneTrackedPlot)) {
+            runtime.navigation.leaveOneTrackedPlot = normalized;
+            runtime.navigation.leaveOneRemainingKills = -1;
+            runtime.navigation.leaveOneUnbudgetedKills = 0;
+            runtime.navigation.leaveOneReservedEntityId = -1;
+        }
+        if (runtime.navigation.leaveOneRemainingKills < 0) {
+            runtime.navigation.leaveOneUnbudgetedKills++;
+            return false;
+        }
+        runtime.navigation.leaveOneRemainingKills =
+                consumeKillBudget(runtime.navigation.leaveOneRemainingKills);
+        return runtime.navigation.leaveOneRemainingKills == 0
+                && finishCurrentPlot(client, runtime, context, currentPlot);
+    }
+
+    static boolean isTrackingPlot(PestDestroyerRuntime runtime, String plot) {
+        return runtime.navigation.leaveOneRemainingKills >= 0
+                && PestPlotId.equals(runtime.navigation.leaveOneTrackedPlot, plot);
     }
 
     static Set<String> filterSkippedPlots(
             PestDestroyerRuntime runtime,
             Set<String> infested) {
+        pruneRememberedPlots(runtime);
         Set<String> filtered = new LinkedHashSet<>();
         for (String plot : infested) {
             if (!runtime.navigation.leaveOneSkippedPlots.contains(PestPlotId.normalize(plot))) {
@@ -104,6 +130,61 @@ final class PestLeaveOneController {
             }
         }
         return filtered;
+    }
+
+    static void forgetPlot(PestDestroyerRuntime runtime, String plot) {
+        String normalized = PestPlotId.normalize(plot);
+        runtime.navigation.leaveOneSkippedPlots.remove(normalized);
+        if (normalized.equals(runtime.navigation.leaveOneTrackedPlot)) {
+            resetTracking(runtime);
+        }
+    }
+
+    static void clearRememberedPlots(PestDestroyerRuntime runtime) {
+        runtime.navigation.leaveOneSkippedPlots.clear();
+        resetTracking(runtime);
+    }
+
+    static boolean shouldFinishForCounts(int aliveCount, int rememberedPlotCount) {
+        return aliveCount == 0 || rememberedPlotCount > 0 && aliveCount <= rememberedPlotCount;
+    }
+
+    static int parsePlotPestCount(List<String> lines, String plot) {
+        String normalizedPlot = PestPlotId.normalize(plot);
+        for (String line : lines) {
+            Matcher matcher = PLOT_PEST_COUNT.matcher(line);
+            if (matcher.find() && PestPlotId.normalize(matcher.group(1)).equals(normalizedPlot)) {
+                return Integer.parseInt(matcher.group(2));
+            }
+        }
+        return -1;
+    }
+
+    static int killBudgetForCount(int pestCount) {
+        return pestCount > 0 ? pestCount - 1 : -1;
+    }
+
+    static int consumeKillBudget(int remainingKills) {
+        return remainingKills > 0 ? remainingKills - 1 : remainingKills;
+    }
+
+    static int remainingKillBudget(int pestCount, int earlyKills) {
+        return Math.max(0, killBudgetForCount(pestCount) - Math.max(0, earlyKills));
+    }
+
+    private static boolean finishCurrentPlot(
+            Minecraft client,
+            PestDestroyerRuntime runtime,
+            Context context,
+            String currentPlot) {
+        runtime.navigation.leaveOneSkippedPlots.add(PestPlotId.normalize(currentPlot));
+        resetTracking(runtime);
+        ClientUtils.sendDebugMessage(
+                "PestDestroyer: leaving one pest alive on whitelisted plot "
+                        + currentPlot
+                        + ".");
+        moveToNextActivePlotOrFinish(client, runtime, context);
+        return true;
     }
 
     private static void moveToNextActivePlotOrFinish(
@@ -148,15 +229,24 @@ final class PestLeaveOneController {
         context.setState(PestDestroyer.State.CHECK_NEXT);
     }
 
-    private static boolean hasOnlyCurrentActivePlot(
-            Minecraft client,
-            PestDestroyerRuntime runtime,
-            String currentPlot) {
-        Set<String> active = filterSkippedPlots(
-                runtime,
-                PestManager.getInfestedPlotsFromTab(client));
-        return active.size() == 1
-                && PestPlotId.equals(active.iterator().next(), currentPlot);
+    private static void pruneRememberedPlots(PestDestroyerRuntime runtime) {
+        if (!AetherConfig.LEAVE_ONE_PEST_ALIVE.get()) {
+            runtime.navigation.leaveOneSkippedPlots.clear();
+            resetTracking(runtime);
+            return;
+        }
+        Set<String> configured = new LinkedHashSet<>();
+        for (String plot : AetherConfig.LEAVE_ONE_PEST_PLOTS.get()) {
+            configured.add(PestPlotId.normalize(plot));
+        }
+        runtime.navigation.leaveOneSkippedPlots.retainAll(configured);
+    }
+
+    private static void resetTracking(PestDestroyerRuntime runtime) {
+        runtime.navigation.leaveOneTrackedPlot = null;
+        runtime.navigation.leaveOneRemainingKills = -1;
+        runtime.navigation.leaveOneUnbudgetedKills = 0;
+        runtime.navigation.leaveOneReservedEntityId = -1;
     }
 
     private static boolean isWhitelistedPlot(String plot) {

--- a/src/main/java/dev/aether/modules/pest/helpers/PestLifecycleManager.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestLifecycleManager.java
@@ -9,6 +9,7 @@ import dev.aether.modules.gear.helpers.LoadoutManager;
 import dev.aether.modules.pest.ManualPestManager;
 import dev.aether.modules.pest.PestManager;
 import dev.aether.util.ClientUtils;
+import dev.aether.util.CommandUtils;
 import net.minecraft.client.Minecraft;
 
 /**
@@ -26,6 +27,8 @@ public final class PestLifecycleManager {
 
     private static volatile Stage stage = Stage.IDLE;
     private static volatile boolean sunsetPestsRestoreNight = false;
+    private static final long SETSPAWN_RETRY_MS = 1_000L;
+    static final int SETSPAWN_MAX_ATTEMPTS = 2;
 
     private PestLifecycleManager() {
     }
@@ -75,8 +78,36 @@ public final class PestLifecycleManager {
 
         boolean manualMode = AetherConfig.MANUAL_PEST_MODE.get();
         stage = Stage.PRE;
-        ClientUtils.sendDebugMessage("Pest lifecycle: entering PRE stage for plot " + plot + ".");
-        client.execute(() -> FarmingMacroManager.disable(client));
+        ClientUtils.sendDebugMessage("Pest lifecycle: waiting for /setspawn while farming continues.");
+        MacroWorkerThread.getInstance().submit("PestSetSpawn-" + plot, () -> {
+            for (int attempt = 0; attempt < SETSPAWN_MAX_ATTEMPTS && isSetSpawnRetryPending(client, sessionId);
+                    attempt++) {
+                if (CommandUtils.setSpawn(SETSPAWN_RETRY_MS)) {
+                    client.execute(() -> beginPreStage(client, plot, pestCount, sessionId, manualMode));
+                    return;
+                }
+                if (attempt + 1 < SETSPAWN_MAX_ATTEMPTS) {
+                    ClientUtils.sendDebugMessage("Pest lifecycle: /setspawn not confirmed; farming and retrying once.");
+                }
+            }
+            if (isSetSpawnRetryPending(client, sessionId)) {
+                ClientUtils.sendDebugMessage("Pest lifecycle: /setspawn failed twice; continuing farming.");
+                PestManager.startPestReentryCooldown();
+            }
+            cancelPendingStart(sessionId);
+        });
+        return true;
+    }
+
+    private static void beginPreStage(Minecraft client, String plot, int pestCount, int sessionId,
+            boolean manualMode) {
+        if (!isSetSpawnRetryPending(client, sessionId)) {
+            cancelPendingStart(sessionId);
+            return;
+        }
+
+        ClientUtils.sendDebugMessage("Pest lifecycle: /setspawn confirmed; entering PRE stage for plot " + plot + ".");
+        FarmingMacroManager.disable(client);
         PestManager.setCleaningInProgress(true);
         PestManager.clearCleaningTriggerPending();
         LoadoutManager.shouldRestartFarmingAfterSwap = false;
@@ -94,7 +125,26 @@ public final class PestLifecycleManager {
                 abortPreStage(client, sessionId);
             }
         });
-        return true;
+    }
+
+    static boolean isSetSpawnRetryPending(Minecraft client, int sessionId) {
+        return shouldRetrySetSpawn(stage, sessionId, PestManager.getCurrentPestSessionId(),
+                PestManager.isCleaningInProgress(),
+                MacroWorkerThread.shouldAbortTask(client, MacroState.State.FARMING));
+    }
+
+    static boolean shouldRetrySetSpawn(Stage currentStage, int sessionId, int currentSessionId,
+            boolean cleaning, boolean abort) {
+        return currentStage == Stage.PRE && sessionId == currentSessionId && !cleaning && !abort;
+    }
+
+    private static void cancelPendingStart(int sessionId) {
+        if (stage == Stage.PRE
+                && sessionId == PestManager.getCurrentPestSessionId()
+                && !PestManager.isCleaningInProgress()) {
+            stage = Stage.IDLE;
+            PestManager.clearCleaningTriggerPending();
+        }
     }
 
     public static void startPostStage(Minecraft client) {

--- a/src/main/java/dev/aether/modules/pest/helpers/PestLifecycleManager.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestLifecycleManager.java
@@ -84,11 +84,14 @@ public final class PestLifecycleManager {
 
         MacroWorkerThread.getInstance().submit("PestPre-" + plot, () -> {
             try {
-                if (!PestPreStage.run(client, plot, sessionId)) {
+                PestPreStage.Result preResult =
+                        PestPreStage.run(client, plot, pestCount, sessionId);
+                if (!preResult.successful()) {
                     abortPreStage(client, sessionId);
                     return;
                 }
-                client.execute(() -> startCleaningStage(client, plot, pestCount, sessionId, manualMode));
+                client.execute(() -> startCleaningStage(
+                        client, plot, pestCount, sessionId, manualMode, preResult));
             } catch (Exception e) {
                 e.printStackTrace();
                 abortPreStage(client, sessionId);
@@ -111,11 +114,30 @@ public final class PestLifecycleManager {
         stage = Stage.IDLE;
     }
 
-    private static void startCleaningStage(Minecraft client, String plot, int pestCount, int sessionId,
-            boolean manualMode) {
+    private static void startCleaningStage(
+            Minecraft client,
+            String plot,
+            int pestCount,
+            int sessionId,
+            boolean manualMode,
+            PestPreStage.Result preResult) {
         if (stage != Stage.PRE
                 || sessionId != PestManager.getCurrentPestSessionId()
                 || !PestManager.isCleaningInProgress()) {
+            return;
+        }
+
+        PestBallsackShredder.Result ballsackResult = preResult.ballsackResult();
+        if (ballsackResult != null && ballsackResult.measured()) {
+            PestManager.decrementPredictedAliveCount(client, ballsackResult.estimatedKilled());
+        }
+        if (ballsackResult != null
+                && ballsackResult.measured()
+                && shouldSkipCleaningAfterBallsack(client, ballsackResult.estimatedRemaining())) {
+            ClientUtils.sendDebugMessage("Ballsack Shredder: "
+                    + ballsackResult.estimatedRemaining()
+                    + " pest(s) estimated remaining; skipping CLEANING and entering POST.");
+            startPostStage(client);
             return;
         }
 
@@ -136,6 +158,12 @@ public final class PestLifecycleManager {
             PestBonusManager.beginReactivation();
         }
         client.execute(() -> PestDestroyer.start(client, plot));
+    }
+
+    static boolean shouldSkipCleaningAfterBallsack(Minecraft client, int estimatedRemaining) {
+        return estimatedRemaining == 0
+                || estimatedRemaining == 1
+                        && PestDestroyer.shouldFinishForAliveCount(client, estimatedRemaining);
     }
 
     private static void abortPreStage(Minecraft client, int sessionId) {

--- a/src/main/java/dev/aether/modules/pest/helpers/PestLifecycleManager.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestLifecycleManager.java
@@ -183,7 +183,7 @@ public final class PestLifecycleManager {
         }
         if (ballsackResult != null
                 && ballsackResult.measured()
-                && shouldSkipCleaningAfterBallsack(client, ballsackResult.estimatedRemaining())) {
+                && shouldSkipCleaningAfterBallsack(client, plot, ballsackResult.estimatedRemaining())) {
             ClientUtils.sendDebugMessage("Ballsack Shredder: "
                     + ballsackResult.estimatedRemaining()
                     + " pest(s) estimated remaining; skipping CLEANING and entering POST.");
@@ -210,10 +210,22 @@ public final class PestLifecycleManager {
         client.execute(() -> PestDestroyer.start(client, plot));
     }
 
-    static boolean shouldSkipCleaningAfterBallsack(Minecraft client, int estimatedRemaining) {
+    static boolean shouldSkipCleaningAfterBallsack(
+            Minecraft client, String targetPlot, int estimatedRemaining) {
+        boolean targetLeavesOnePest = AetherConfig.LEAVE_ONE_PEST_ALIVE.get()
+                && AetherConfig.LEAVE_ONE_PEST_PLOTS.get().stream()
+                        .map(PestPlotId::normalize)
+                        .anyMatch(PestPlotId.normalize(targetPlot)::equals);
+        return shouldSkipCleaningAfterBallsack(
+                estimatedRemaining,
+                targetLeavesOnePest,
+                PestDestroyer.shouldFinishForAliveCount(client, estimatedRemaining));
+    }
+
+    static boolean shouldSkipCleaningAfterBallsack(
+            int estimatedRemaining, boolean targetLeavesOnePest, boolean rememberedLeavesCanFinish) {
         return estimatedRemaining == 0
-                || estimatedRemaining == 1
-                        && PestDestroyer.shouldFinishForAliveCount(client, estimatedRemaining);
+                || estimatedRemaining == 1 && (targetLeavesOnePest || rememberedLeavesCanFinish);
     }
 
     private static void abortPreStage(Minecraft client, int sessionId) {

--- a/src/main/java/dev/aether/modules/pest/helpers/PestNavigationState.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestNavigationState.java
@@ -22,6 +22,10 @@ final class PestNavigationState {
     CommandUtils.ChatWindow plotTpWindow = null;
     final List<String> plotQueue = new ArrayList<>();
     final Set<String> leaveOneSkippedPlots = ConcurrentHashMap.newKeySet();
+    String leaveOneTrackedPlot = null;
+    int leaveOneRemainingKills = -1;
+    int leaveOneUnbudgetedKills = 0;
+    int leaveOneReservedEntityId = -1;
     int currentPlotIdx = 0;
     String lastTargetPlot = null;
     String trustedPlot = null;
@@ -39,7 +43,10 @@ final class PestNavigationState {
         plotTpSent = false;
         plotTpWindow = null;
         plotQueue.clear();
-        leaveOneSkippedPlots.clear();
+        leaveOneTrackedPlot = null;
+        leaveOneRemainingKills = -1;
+        leaveOneUnbudgetedKills = 0;
+        leaveOneReservedEntityId = -1;
         currentPlotIdx = 0;
         lastTargetPlot = null;
         trustedPlot = null;

--- a/src/main/java/dev/aether/modules/pest/helpers/PestPreStage.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestPreStage.java
@@ -43,6 +43,9 @@ final class PestPreStage {
             return false;
         }
 
+        if (AetherConfig.BALLSACK_SHREDDER.get()) {
+            return PestBallsackShredder.run(client, sessionId);
+        }
         return moveToRoofIfNeeded(client, plot, sessionId);
     }
 
@@ -61,7 +64,7 @@ final class PestPreStage {
         }
 
         boolean forcePlotTp =
-                alreadyOnPlot && AetherConfig.PEST_PLOT_TP_FOR_CURRENT_PLOT.get();
+                alreadyOnPlot && (AetherConfig.PEST_PLOT_TP_FOR_CURRENT_PLOT.get() || AetherConfig.BALLSACK_SHREDDER.get());
 
         if (alreadyOnPlot && !forcePlotTp) {
             String source = chatMatch ? "chat" : "scoreboard";

--- a/src/main/java/dev/aether/modules/pest/helpers/PestPreStage.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestPreStage.java
@@ -22,12 +22,6 @@ final class PestPreStage {
             return false;
         }
 
-        if (!CommandUtils.setSpawn()) {
-            ClientUtils.sendMessage("\u00A7c[Aether] /setspawn timed out - aborting pest cleaning to prevent roof spawn.",
-                    false);
-            return false;
-        }
-
         if (AetherConfig.SUNSET_PESTS.get()) {
             if (!PestLifecycleManager.prepareSunsetPestsDaytime(client)) {
                 return false;

--- a/src/main/java/dev/aether/modules/pest/helpers/PestPreStage.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestPreStage.java
@@ -125,12 +125,18 @@ final class PestPreStage {
 
         ClientUtils.waitForWardrobeGui();
         long finishWait = System.currentTimeMillis();
-        while (LoadoutManager.isSwappingLoadout && System.currentTimeMillis() - finishWait < 7000) {
+        while ((LoadoutManager.isSwappingLoadout || !LoadoutManager.loadoutGuiCloseComplete)
+                && System.currentTimeMillis() - finishWait < 7000) {
             MacroWorkerThread.sleep(50);
         }
-        if (LoadoutManager.isSwappingLoadout) {
+        if (LoadoutManager.isSwappingLoadout || !LoadoutManager.loadoutGuiCloseComplete) {
             ClientUtils.sendDebugMessage("Loadout swap timed out in pest PRE stage; triggering completion failsafe.");
             LoadoutManager.forceLoadoutCompletionFailsafe(client);
+            long failsafeWait = System.currentTimeMillis();
+            while (!LoadoutManager.loadoutGuiCloseComplete
+                    && System.currentTimeMillis() - failsafeWait < 2000) {
+                MacroWorkerThread.sleep(25);
+            }
         }
 
         while (LoadoutManager.loadoutCleanupTicks > 0) {

--- a/src/main/java/dev/aether/modules/pest/helpers/PestPreStage.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestPreStage.java
@@ -14,39 +14,53 @@ import net.minecraft.client.Minecraft;
  */
 final class PestPreStage {
 
+    record Result(boolean successful, PestBallsackShredder.Result ballsackResult) {
+        static Result success() {
+            return new Result(true, null);
+        }
+
+        static Result failure() {
+            return new Result(false, null);
+        }
+    }
+
     private PestPreStage() {
     }
 
-    static boolean run(Minecraft client, String plot, int sessionId) throws InterruptedException {
+    static Result run(Minecraft client, String plot, int pestCount, int sessionId) throws InterruptedException {
         if (shouldAbort(client, sessionId)) {
-            return false;
+            return Result.failure();
         }
 
         if (!CommandUtils.setSpawn()) {
             ClientUtils.sendMessage("\u00A7c[Aether] /setspawn timed out - aborting pest cleaning to prevent roof spawn.",
                     false);
-            return false;
+            return Result.failure();
         }
 
         if (AetherConfig.SUNSET_PESTS.get()) {
             if (!PestLifecycleManager.prepareSunsetPestsDaytime(client)) {
-                return false;
+                return Result.failure();
             }
         }
 
         if (!swapToPestLoadout(client, sessionId)) {
-            return false;
+            return Result.failure();
         }
 
         PestPrepSwapManager.clearCycleState();
         if (!moveToTargetPlot(client, plot, sessionId)) {
-            return false;
+            return Result.failure();
         }
 
         if (AetherConfig.BALLSACK_SHREDDER.get()) {
-            return PestBallsackShredder.run(client, sessionId);
+            PestBallsackShredder.Result result =
+                    PestBallsackShredder.run(client, sessionId, pestCount);
+            return new Result(result.successful(), result);
         }
-        return moveToRoofIfNeeded(client, plot, sessionId);
+        return moveToRoofIfNeeded(client, plot, sessionId)
+                ? Result.success()
+                : Result.failure();
     }
 
     private static boolean moveToTargetPlot(Minecraft client, String plot, int sessionId) {

--- a/src/main/java/dev/aether/modules/pest/helpers/PestPrepSwapManager.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestPrepSwapManager.java
@@ -2,6 +2,7 @@ package dev.aether.modules.pest.helpers;
 
 import dev.aether.config.AetherConfig;
 import dev.aether.macro.MacroState;
+import dev.aether.macro.MacroStateManager;
 import dev.aether.macro.MacroWorkerThread;
 import dev.aether.modules.gear.GearManager;
 import dev.aether.modules.gear.helpers.LoadoutManager;
@@ -71,19 +72,8 @@ public class PestPrepSwapManager {
                 if (shouldAbortPrepSwap()) {
                     return;
                 }
-                ClientUtils.sendDebugMessage("Disabling farming macro: Triggering prep-swap");
-                client.execute(() -> dev.aether.macro.farming.FarmingMacroManager.disable(client));
-                MacroWorkerThread.sleep(400);
-                if (shouldAbortPrepSwap()) {
-                    return;
-                }
-
                 if (!runPrepLoadoutSwap()) {
                     return;
-                }
-
-                if (!PestManager.isCleaningInProgress()) {
-                    GearManager.finalResume(client);
                 }
             } catch (Exception e) {
                 e.printStackTrace();
@@ -107,7 +97,11 @@ public class PestPrepSwapManager {
 
     private static boolean shouldAbortPrepSwap() {
         Minecraft client = client();
-        if (MacroWorkerThread.shouldAbortTask(client, MacroState.State.FARMING) || PestManager.isCleaningInProgress()) {
+        if ((MacroWorkerThread.shouldAbortTask(client)
+                && !LoadoutManager.isSwappingLoadout)
+                || (MacroStateManager.getCurrentState() != MacroState.State.FARMING
+                        && !LoadoutManager.isSwappingLoadout)
+                || PestManager.isCleaningInProgress()) {
             if (dev.aether.macro.MacroStateManager.getCurrentState() != MacroState.State.FARMING
                     || !dev.aether.macro.MacroStateManager.isMacroRunning()) {
                 prepSwappedForCurrentPestCycle = false;
@@ -124,7 +118,7 @@ public class PestPrepSwapManager {
         }
 
         ClientUtils.sendDebugMessage("Prep-swap: Initiating loadout swap to slot " + AetherConfig.LOADOUT_SLOT_PEST.get());
-        GearManager.ensureLoadoutSlot(client, AetherConfig.LOADOUT_SLOT_PEST.get());
+        GearManager.triggerLoadoutSwap(client, AetherConfig.LOADOUT_SLOT_PEST.get());
         if (!LoadoutManager.isSwappingLoadout) {
             ClientUtils.sendDebugMessage("Prep-swap: Loadout swap not needed (already on correct slot).");
             return !shouldAbortPrepSwap();
@@ -139,7 +133,7 @@ public class PestPrepSwapManager {
                 return false;
             }
 
-            GearManager.ensureLoadoutSlot(client, AetherConfig.LOADOUT_SLOT_PEST.get());
+            GearManager.triggerLoadoutSwap(client, AetherConfig.LOADOUT_SLOT_PEST.get());
             if (LoadoutManager.isSwappingLoadout) {
                 ClientUtils.sendDebugMessage("Prep-swap: Retry - Waiting for loadout GUI...");
                 ClientUtils.waitForWardrobeGui();
@@ -155,10 +149,6 @@ public class PestPrepSwapManager {
             MacroWorkerThread.sleep(50);
         }
         MacroWorkerThread.sleep(250);
-        if (shouldAbortPrepSwap()) {
-            return false;
-        }
-
         ClientUtils.sendDebugMessage("Prep-swap: Loadout swap completed.");
         return true;
     }

--- a/src/main/java/dev/aether/modules/pest/helpers/PestPrepSwapManager.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestPrepSwapManager.java
@@ -145,7 +145,8 @@ public class PestPrepSwapManager {
             }
         }
 
-        while (LoadoutManager.isSwappingLoadout && !PestManager.isCleaningInProgress()) {
+        while ((LoadoutManager.isSwappingLoadout || !LoadoutManager.loadoutGuiCloseComplete)
+                && !PestManager.isCleaningInProgress()) {
             MacroWorkerThread.sleep(50);
         }
         MacroWorkerThread.sleep(250);

--- a/src/main/java/dev/aether/modules/pest/helpers/PestReturnManager.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestReturnManager.java
@@ -232,6 +232,10 @@ public class PestReturnManager {
     public static void performUnfly(Minecraft client) throws InterruptedException {
         if (client.player == null)
             return;
+        if (!client.player.getAbilities().flying) {
+            ClientUtils.sendDebugMessage("Finisher: player is already grounded; skipping unfly.");
+            return;
+        }
 
         if (ConfigHelpers.getUnflyMode() == UnflyMode.DOUBLE_TAP_SPACE) {
             isStoppingFlight = true;

--- a/src/main/java/dev/aether/modules/pest/helpers/PestRoofAotvController.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestRoofAotvController.java
@@ -54,10 +54,17 @@ final class PestRoofAotvController {
         runtime.aotvStartY = Double.NaN;
         releaseAotvKeys(client);
         float targetYaw = client.player.getYRot() + (float) (-10.0 + Math.random() * 20.0);
-        float targetPitch = (float) (-30.0 + Math.random() * 60.0);
+        float targetPitch = AetherConfig.BALLSACK_SHREDDER.get()
+                ? 90.0f
+                : (float) (-30.0 + Math.random() * 60.0);
         RotationManager.rotateToYawPitch(
                 client, targetYaw, targetPitch, AetherConfig.ROTATION_TIME.get(), true);
-        PestDestroyer.setState(PestDestroyer.State.AOTV_TO_ROOF_RETURN);
+        if (AetherConfig.BALLSACK_SHREDDER.get()) {
+            PestAotvManager.setSneakingForAotv(false);
+            PestDestroyer.setState(PestDestroyer.State.AOTV_POST_LOOKDOWN);
+        } else {
+            PestDestroyer.setState(PestDestroyer.State.AOTV_TO_ROOF_RETURN);
+        }
     }
 
     private static void recoverTimedOutClimb(Minecraft client, PestDestroyerRuntime runtime) {

--- a/src/main/java/dev/aether/modules/pest/helpers/PestTargetController.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestTargetController.java
@@ -9,7 +9,11 @@ import dev.aether.util.ClientUtils;
 import dev.aether.util.RotationUtils;
 import net.minecraft.client.Minecraft;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.phys.Vec3;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /** Owns target discovery, queueing, handoff, and kill accounting. */
 final class PestTargetController {
@@ -176,6 +180,60 @@ final class PestTargetController {
         context.setState(PestDestroyer.State.CHECK_NEXT);
     }
 
+    static boolean reconcileTrackedKills(
+            Minecraft client,
+            PestDestroyerRuntime runtime,
+            Context context) {
+        if (!runtime.active || runtime.state != PestDestroyer.State.KILL_PEST) {
+            return false;
+        }
+
+        Map<Integer, Entity> trackedTargets = new LinkedHashMap<>();
+        if (runtime.currentTarget != null) {
+            trackedTargets.put(runtime.currentTarget.getId(), runtime.currentTarget);
+        }
+        for (Entity queuedTarget : runtime.pestTargetQueue) {
+            trackedTargets.putIfAbsent(queuedTarget.getId(), queuedTarget);
+        }
+
+        int newlyKilled = 0;
+        boolean currentTargetDied = false;
+        for (Entity entity : trackedTargets.values()) {
+            if (!isDead(entity)) {
+                continue;
+            }
+            if (!runtime.killedEntities.contains(entity)) {
+                runtime.killedEntities.add(entity);
+            }
+            if (runtime.claimKilledPestEntityId(entity.getId())) {
+                newlyKilled++;
+            }
+            if (entity == runtime.currentTarget) {
+                currentTargetDied = true;
+            }
+        }
+
+        if (newlyKilled == 0) {
+            return false;
+        }
+
+        runtime.pestTargetQueue.removeIf(PestTargetController::isDead);
+        PestManager.decrementPredictedAliveCount(client, newlyKilled);
+        if (!runtime.active) {
+            return true;
+        }
+
+        if (currentTargetDied) {
+            runtime.currentTarget = null;
+            if (client.options != null) {
+                ClientUtils.setKeyMappingState(client.options.keyUse, false);
+                ClientUtils.setKeyMappingState(client.options.keyDown, false);
+            }
+            context.setState(PestDestroyer.State.CHECK_NEXT);
+        }
+        return true;
+    }
+
     static boolean recordTrackedKill(
             Minecraft client,
             PestDestroyerRuntime runtime,
@@ -187,11 +245,16 @@ final class PestTargetController {
         if (!runtime.killedEntities.contains(entity)) {
             runtime.killedEntities.add(entity);
         }
-        if (!runtime.accountedKilledPestEntityIds.add(entity.getId())) {
+        if (!runtime.claimKilledPestEntityId(entity.getId())) {
             return false;
         }
         PestManager.decrementPredictedAliveCount(client);
-        return false;
+        return !runtime.active;
+    }
+
+    private static boolean isDead(Entity entity) {
+        return entity.isRemoved()
+                || entity instanceof LivingEntity living && living.isDeadOrDying();
     }
 
     static boolean isLookingAt(Minecraft client, Vec3 targetPosition, float tolerance) {

--- a/src/main/java/dev/aether/modules/pest/helpers/PestTargetController.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestTargetController.java
@@ -23,10 +23,8 @@ final class PestTargetController {
             TARGET_REACH_DISTANCE * PRE_TRIGGER_RATIO;
     private static final double PRE_MOVE_MIN_NEXT_DIST = 2.5;
 
-    interface Context {
+    interface Context extends PestLeaveOneController.Context {
         boolean tryLeaveOneOnCurrentPlot(Minecraft client);
-
-        void setState(PestDestroyer.State state);
     }
 
     private PestTargetController() {
@@ -95,7 +93,7 @@ final class PestTargetController {
 
         Entity next = nextQueuedPest(client, runtime);
         if (next == null) {
-            rebuildQueue(client, runtime);
+            rebuildQueue(client, runtime, context);
             next = nextQueuedPest(client, runtime);
         }
         if (next == null) {
@@ -125,9 +123,16 @@ final class PestTargetController {
                 client, runtime.pestTargetQueue, runtime.killedEntities);
     }
 
-    static void rebuildQueue(Minecraft client, PestDestroyerRuntime runtime) {
+    static void rebuildQueue(
+            Minecraft client,
+            PestDestroyerRuntime runtime,
+            Context context) {
+        updateReservedPest(client, runtime, context);
         PestTargetTracker.rebuildPestTargetQueue(
-                client, runtime.pestTargetQueue, runtime.killedEntities);
+                client,
+                runtime.pestTargetQueue,
+                runtime.killedEntities,
+                runtime.navigation.leaveOneReservedEntityId);
     }
 
     static Entity nextQueuedPest(Minecraft client, PestDestroyerRuntime runtime) {
@@ -135,16 +140,19 @@ final class PestTargetController {
                 client, runtime.pestTargetQueue, runtime.killedEntities);
     }
 
-    static Entity findClosestPest(Minecraft client, PestDestroyerRuntime runtime) {
-        return PestTargetTracker.findClosestPest(client, runtime.killedEntities);
+    static Entity findClosestPest(
+            Minecraft client,
+            PestDestroyerRuntime runtime,
+            Context context) {
+        updateReservedPest(client, runtime, context);
+        return PestTargetTracker.findClosestPest(
+                client,
+                runtime.killedEntities,
+                runtime.navigation.leaveOneReservedEntityId);
     }
 
     static int countVisiblePestSkulls(Minecraft client) {
         return PestTargetTracker.countVisiblePestSkulls(client);
-    }
-
-    static int countAvailablePests(Minecraft client, PestDestroyerRuntime runtime) {
-        return PestTargetTracker.countAvailablePests(client, runtime.killedEntities);
     }
 
     static boolean hasPestSkullMarkerForTarget(Minecraft client, Entity target) {
@@ -191,7 +199,29 @@ final class PestTargetController {
             return false;
         }
         PestManager.decrementPredictedAliveCount(client);
-        return false;
+        return PestLeaveOneController.recordTrackedKill(client, runtime, context);
+    }
+
+    private static void updateReservedPest(
+            Minecraft client,
+            PestDestroyerRuntime runtime,
+            Context context) {
+        if (!PestLeaveOneController.isTrackingPlot(
+                runtime, context.getEffectivePlot(client))) {
+            runtime.navigation.leaveOneReservedEntityId = -1;
+            return;
+        }
+        int reservedId = runtime.navigation.leaveOneReservedEntityId;
+        boolean reservedStillAvailable = reservedId != -1
+                && PestTargetTracker.isAvailablePest(
+                        client, runtime.killedEntities, reservedId);
+        Entity reserved = PestTargetTracker.findMostIsolatedPest(
+                client, runtime.killedEntities);
+        if (reserved != null) {
+            runtime.navigation.leaveOneReservedEntityId = reserved.getId();
+        } else if (!reservedStillAvailable) {
+            runtime.navigation.leaveOneReservedEntityId = -1;
+        }
     }
 
     static boolean isLookingAt(Minecraft client, Vec3 targetPosition, float tolerance) {

--- a/src/main/java/dev/aether/modules/pest/helpers/PestTargetTracker.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestTargetTracker.java
@@ -21,6 +21,7 @@ import java.util.Deque;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.IdentityHashMap;
 import java.util.function.Predicate;
 
 public final class PestTargetTracker {
@@ -79,10 +80,21 @@ public final class PestTargetTracker {
     static void rebuildPestTargetQueue(
             Minecraft client,
             Deque<Entity> pestTargetQueue,
-            Collection<Entity> killedEntities
+            Collection<Entity> killedEntities,
+            int reservedEntityId
     ) {
         List<Entity> pests = availableTargets(client, killedEntities);
-        if (client.player != null) {
+        if (reservedEntityId != -1) {
+            Map<Entity, Double> nearestNeighborDistances = new IdentityHashMap<>();
+            List<Vec3> positions = pests.stream().map(Entity::position).toList();
+            for (int i = 0; i < pests.size(); i++) {
+                nearestNeighborDistances.put(pests.get(i), nearestNeighborDistanceSqr(i, positions));
+            }
+            pests.removeIf(pest -> pest.getId() == reservedEntityId);
+            pests.sort(Comparator
+                    .comparingDouble((Entity pest) -> nearestNeighborDistances.get(pest))
+                    .thenComparingDouble(client.player::distanceToSqr));
+        } else if (client.player != null) {
             pests.sort(Comparator.comparingDouble(client.player::distanceToSqr));
         }
         pestTargetQueue.clear();
@@ -93,16 +105,16 @@ public final class PestTargetTracker {
         }
     }
 
-    static int countAvailablePests(Minecraft client, Collection<Entity> killedEntities) {
-        return availableTargets(client, killedEntities).size();
-    }
-
-    static Entity findClosestPest(Minecraft client, Collection<Entity> killedEntities) {
+    static Entity findClosestPest(
+            Minecraft client,
+            Collection<Entity> killedEntities,
+            int reservedEntityId) {
         if (client == null || client.player == null) {
             return null;
         }
         List<Entity> targets = availableTargets(client, killedEntities);
         Entity closest = targets.stream()
+                .filter(target -> target.getId() != reservedEntityId)
                 .min(Comparator.comparingDouble(client.player::distanceToSqr))
                 .orElse(null);
         PestSnapshot snapshot = snapshot(client);
@@ -110,6 +122,47 @@ public final class PestTargetTracker {
                 + " entities, " + snapshot.markers().size() + " pest markers, "
                 + targets.size() + " available pests");
         return closest;
+    }
+
+    static Entity findMostIsolatedPest(Minecraft client, Collection<Entity> killedEntities) {
+        List<Entity> pests = availableTargets(client, killedEntities);
+        if (pests.size() < 2) {
+            return null;
+        }
+        List<Vec3> positions = pests.stream().map(Entity::position).toList();
+        return pests.get(mostIsolatedIndex(positions));
+    }
+
+    static boolean isAvailablePest(
+            Minecraft client,
+            Collection<Entity> killedEntities,
+            int entityId) {
+        return availableTargets(client, killedEntities).stream()
+                .anyMatch(pest -> pest.getId() == entityId);
+    }
+
+    // ponytail: O(n^2) is simpler and pests are single-digit; spatial indexing only if that ceiling changes.
+    static int mostIsolatedIndex(List<Vec3> positions) {
+        int mostIsolated = -1;
+        double bestDistance = -1.0;
+        for (int i = 0; i < positions.size(); i++) {
+            double distance = nearestNeighborDistanceSqr(i, positions);
+            if (distance > bestDistance) {
+                bestDistance = distance;
+                mostIsolated = i;
+            }
+        }
+        return mostIsolated;
+    }
+
+    private static double nearestNeighborDistanceSqr(int index, List<Vec3> positions) {
+        double nearest = Double.MAX_VALUE;
+        for (int i = 0; i < positions.size(); i++) {
+            if (i != index) {
+                nearest = Math.min(nearest, positions.get(index).distanceToSqr(positions.get(i)));
+            }
+        }
+        return nearest;
     }
 
     static boolean hasPestArmorStandNearby(Minecraft client, Entity targetEntity) {

--- a/src/main/java/dev/aether/modules/visitor/VisitorsMacro.java
+++ b/src/main/java/dev/aether/modules/visitor/VisitorsMacro.java
@@ -17,6 +17,7 @@ import dev.aether.modules.rotation.RotationManager;
 import dev.aether.util.BazaarUtils;
 import dev.aether.util.ClientUtils;
 import dev.aether.util.CommandUtils;
+import dev.aether.util.EntityUtils;
 import dev.aether.util.TablistUtils;
 import dev.aether.util.RotationUtils;
 import net.minecraft.client.Minecraft;
@@ -25,7 +26,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.decoration.ArmorStand;
 import net.minecraft.world.inventory.ContainerInput;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.Item;
@@ -602,55 +602,9 @@ public class VisitorsMacro {
     // -- Entity Finding --
 
     private static Entity findVisitorEntity(Minecraft client, String visitorName) {
-        if (client.level == null || client.player == null)
-            return null;
-
-        String target = normalizeVisitorName(visitorName);
-
-        // Look for armor stands with matching name (visitor NPCs have name tags)
-        Entity best = null;
-        double bestDist = Double.MAX_VALUE;
-
-        for (Entity entity : client.level.entitiesForRendering()) {
-            if (entity == client.player)
-                continue;
-            String entityName = normalizeVisitorName(entity.getName().getString());
-
-            if (entityName.equals(target)) {
-                double dist = entity.distanceToSqr(client.player);
-                // Prefer non-armor-stand entities (the actual NPC character)
-                // but accept armor stands if that's all we find
-                if (!(entity instanceof ArmorStand)) {
-                    if (dist < bestDist || best instanceof ArmorStand) {
-                        bestDist = dist;
-                        best = entity;
-                    }
-                } else if (best == null) {
-                    bestDist = dist;
-                    best = entity;
-                }
-            }
-        }
-
-        // If we only found an armor stand, try to find the actual character near it
-        if (best instanceof ArmorStand) {
-            Entity character = findCharacterNearArmorStand(client, best);
-            if (character != null)
-                return character;
-        }
-
-        return best;
-    }
-
-    private static Entity findCharacterNearArmorStand(Minecraft client, Entity armorStand) {
-        for (Entity entity : client.level.entitiesForRendering()) {
-            if (entity == client.player || entity instanceof ArmorStand)
-                continue;
-            if (entity.distanceToSqr(armorStand) < 4.0) {
-                return entity;
-            }
-        }
-        return null;
+        // Keep visitor targeting consistent with /aether interact, including
+        // exact-name preference and armor-stand-to-NPC resolution.
+        return EntityUtils.findEntity(client, visitorName);
     }
 
     // -- Movement / Interaction --
@@ -893,6 +847,29 @@ public class VisitorsMacro {
                         ClientUtils.sendDebugMessage("[VisitorsMacro] Closing wrong visitor GUI while targeting " + visitorName + ".");
                         closeScreen(client);
                         MacroWorkerThread.sleep(250);
+                        prepRetries++;
+                        if (prepRetries > MAX_VISITOR_INTERACTION_RETRIES) {
+                            return false;
+                        }
+
+                        // A wrong GUI means the last ray trace hit another NPC.
+                        // Force a fresh path even if we are inside the normal
+                        // interaction radius; otherwise the next click can hit
+                        // the same NPC again indefinitely.
+                        Entity targetVisitor = findVisitorEntity(client, visitorName);
+                        if (targetVisitor == null) {
+                            continue;
+                        }
+                        currentVisitorRetrySneak = true;
+                        walkToEntity(client, targetVisitor, VISITOR_RETRY_RANGE);
+                        if (shouldStop) {
+                            return false;
+                        }
+                        entity = findVisitorEntity(client, visitorName);
+                        if (entity == null) {
+                            continue;
+                        }
+                        faceVisitorForInteraction(client, entity);
                         break;
                     }
                     return true;

--- a/src/main/java/dev/aether/ui/providers/modules/FarmingSettingsFactory.java
+++ b/src/main/java/dev/aether/ui/providers/modules/FarmingSettingsFactory.java
@@ -52,13 +52,15 @@ final class FarmingSettingsFactory {
     }
 
     static RangeSliderSetting pestDestroyerTriggerDelaySetting() {
-        return intDelayRangeSetting("Pest Destroyer Trigger Delay", 0f, 5000f,
-                () -> AetherConfig.PEST_CHAT_TRIGGER_DELAY_MIN.get(),
-                () -> AetherConfig.PEST_CHAT_TRIGGER_DELAY_MAX.get(),
-                (min, max) -> {
-                    AetherConfig.PEST_CHAT_TRIGGER_DELAY_MIN.set(min);
-                    AetherConfig.PEST_CHAT_TRIGGER_DELAY_MAX.set(max);
-                });
+        return new RangeSliderSetting("Pest Destroyer Trigger Delay", 0f, 30f,
+                () -> AetherConfig.PEST_CHAT_TRIGGER_DELAY_MIN.get() / 1000f,
+                () -> AetherConfig.PEST_CHAT_TRIGGER_DELAY_MAX.get() / 1000f,
+                (lower, upper) -> {
+                    AetherConfig.PEST_CHAT_TRIGGER_DELAY_MIN.set(Math.round(lower * 1000f));
+                    AetherConfig.PEST_CHAT_TRIGGER_DELAY_MAX.set(Math.round(upper * 1000f));
+                    AetherConfig.save();
+                })
+                .withDecimals(1).withSuffix("s");
     }
 
     static RangeSliderSetting pestExchangeDelaySetting() {
@@ -200,11 +202,17 @@ final class FarmingSettingsFactory {
                 .withDecimals(0).withSuffix("s");
     }
 
-    static SliderSetting aotvToRoofPitchRangeSetting() {
-        return new SliderSetting("AOTV to Roof Pitch Range", 0, 15,
-                () -> (float) AetherConfig.AOTV_ROOF_PITCH_HUMANIZATION.get(),
-                v -> {
-                    AetherConfig.AOTV_ROOF_PITCH_HUMANIZATION.set(Math.round(v));
+    static RangeSliderSetting aotvToRoofPitchSetting() {
+        return new RangeSliderSetting("AOTV to Roof Pitch", 0, 90,
+                () -> (float) Math.max(0, AetherConfig.AOTV_ROOF_PITCH.get()
+                        - AetherConfig.AOTV_ROOF_PITCH_HUMANIZATION.get()),
+                () -> (float) Math.min(90, AetherConfig.AOTV_ROOF_PITCH.get()
+                        + AetherConfig.AOTV_ROOF_PITCH_HUMANIZATION.get()),
+                (lower, upper) -> {
+                    int min = Math.round(lower);
+                    int max = Math.round(upper);
+                    AetherConfig.AOTV_ROOF_PITCH.set((min + max) / 2);
+                    AetherConfig.AOTV_ROOF_PITCH_HUMANIZATION.set((max - min) / 2);
                     AetherConfig.save();
                 })
                 .withDecimals(0).withSuffix("\u00B0");

--- a/src/main/java/dev/aether/ui/providers/modules/HumanizationRegistryProvider.java
+++ b/src/main/java/dev/aether/ui/providers/modules/HumanizationRegistryProvider.java
@@ -118,7 +118,6 @@ public final class HumanizationRegistryProvider extends AbstractModulesRegistryP
                         "Angle ranges and target tolerance settings")
                 .add(FarmingSettingsFactory.farmingPitchRangeSetting())
                 .add(FarmingSettingsFactory.farmingYawRangeSetting())
-                .add(FarmingSettingsFactory.aotvToRoofPitchRangeSetting())
                 .add(FarmingSettingsFactory.pestFovRangeSetting())
                 .add(FarmingSettingsFactory.pestAboveAimPitchRangeSetting())
                 .add(FarmingSettingsFactory.visitorFovRangeSetting())

--- a/src/main/java/dev/aether/ui/providers/modules/PestManagerRegistryProvider.java
+++ b/src/main/java/dev/aether/ui/providers/modules/PestManagerRegistryProvider.java
@@ -208,14 +208,7 @@ public final class PestManagerRegistryProvider extends AbstractModulesRegistryPr
                             AetherConfig.AOTV_ROOF_PLOTS.set(v);
                             AetherConfig.save();
                         }))
-                .add(new SliderSetting("AOTV to Roof Pitch", 20, 90,
-                        () -> (float) AetherConfig.AOTV_ROOF_PITCH.get(),
-                        v -> {
-                            AetherConfig.AOTV_ROOF_PITCH.set(Math.round(v));
-                            AetherConfig.save();
-                        })
-                        .withDecimals(0).withSuffix("\u00B0"))
-                .add(FarmingSettingsFactory.aotvToRoofPitchRangeSetting())
+                .add(FarmingSettingsFactory.aotvToRoofPitchSetting())
                 .add(new ToggleSetting("Break Blocks Before AOTV",
                         () -> AetherConfig.BREAK_BLOCKS_BEFORE_AOTV.get(),
                         v -> {

--- a/src/main/java/dev/aether/ui/providers/modules/PestManagerRegistryProvider.java
+++ b/src/main/java/dev/aether/ui/providers/modules/PestManagerRegistryProvider.java
@@ -138,6 +138,44 @@ public final class PestManagerRegistryProvider extends AbstractModulesRegistryPr
                 .add(FarmingSettingsFactory.pestFovRangeSetting())
                 .add(FarmingSettingsFactory.pestAboveAimPitchRangeSetting()));
         groups.add(SettingGroup.of(
+                        "Ballsack Shredder",
+                        "Uses a dedicated AOTV sequence before pest cleaning",
+                        AetherConfig.BALLSACK_SHREDDER::get,
+                        v -> {
+                            AetherConfig.BALLSACK_SHREDDER.set(v);
+                            AetherConfig.save();
+                        })
+                .add(FarmingSettingsFactory.pestDestroyerTriggerDelaySetting())
+                .add(new SliderSetting("Look Down Time", 0, 3000,
+                        () -> (float) AetherConfig.BALLSACK_LOOK_DOWN_TIME_MS.get(),
+                        v -> {
+                            AetherConfig.BALLSACK_LOOK_DOWN_TIME_MS.set(Math.round(v));
+                            AetherConfig.save();
+                        })
+                        .withDecimals(0).withSuffix("ms")));
+
+        groups.add(SettingGroup.of(
+                        "AOTV to Roof",
+                        "Teleports to the roof before cleaning pests on selected plots",
+                        () -> AetherConfig.AOTV_TO_ROOF.get(),
+                        v -> {
+                            AetherConfig.AOTV_TO_ROOF.set(v);
+                            AetherConfig.save();
+                        })
+                .add(new ListSetting("AOTV Roof Plots", "Add plot number",
+                        () -> AetherConfig.AOTV_ROOF_PLOTS.get(),
+                        v -> {
+                            AetherConfig.AOTV_ROOF_PLOTS.set(v);
+                            AetherConfig.save();
+                        }))
+                .add(FarmingSettingsFactory.aotvToRoofPitchSetting())
+                .add(new ToggleSetting("Break Blocks Before AOTV",
+                        () -> AetherConfig.BREAK_BLOCKS_BEFORE_AOTV.get(),
+                        v -> {
+                            AetherConfig.BREAK_BLOCKS_BEFORE_AOTV.set(v);
+                            AetherConfig.save();
+                        })));
+        groups.add(SettingGroup.of(
                 "On-The-Track Pest",
                 "Pauses farming briefly to vacuum pests already within reach",
                 () -> AetherConfig.PEST_ON_TRACK_ENABLED.get(),
@@ -193,28 +231,6 @@ public final class PestManagerRegistryProvider extends AbstractModulesRegistryPr
                         .addIconAction("/assets/aether/icons/refresh.svg", () -> refreshSoundOptions(manualPestSoundOptions)))
                 .add(new KeybindSetting("Manual Pest Early Finish",
                         AetherKeybindRegistry.getManualPestEarlyFinishKey())));
-
-        groups.add(SettingGroup.of(
-                        "AOTV to Roof",
-                        "Teleports to the roof before cleaning pests on selected plots",
-                        () -> AetherConfig.AOTV_TO_ROOF.get(),
-                        v -> {
-                            AetherConfig.AOTV_TO_ROOF.set(v);
-                            AetherConfig.save();
-                        })
-                .add(new ListSetting("AOTV Roof Plots", "Add plot number",
-                        () -> AetherConfig.AOTV_ROOF_PLOTS.get(),
-                        v -> {
-                            AetherConfig.AOTV_ROOF_PLOTS.set(v);
-                            AetherConfig.save();
-                        }))
-                .add(FarmingSettingsFactory.aotvToRoofPitchSetting())
-                .add(new ToggleSetting("Break Blocks Before AOTV",
-                        () -> AetherConfig.BREAK_BLOCKS_BEFORE_AOTV.get(),
-                        v -> {
-                            AetherConfig.BREAK_BLOCKS_BEFORE_AOTV.set(v);
-                            AetherConfig.save();
-                        })));
 
         groups.add(SettingGroup.of(
                         "Pest Traps",

--- a/src/main/java/dev/aether/util/BazaarUtils.java
+++ b/src/main/java/dev/aether/util/BazaarUtils.java
@@ -606,11 +606,7 @@ public final class BazaarUtils {
     }
 
     private static void closeScreen(Minecraft client) {
-        client.execute(() -> {
-            if (client.player != null && client.screen != null) {
-                client.player.closeContainer();
-            }
-        });
+        ClientUtils.closeGui(client);
     }
 
     private static String stripColors(String s) {

--- a/src/main/java/dev/aether/util/ClientUtils.java
+++ b/src/main/java/dev/aether/util/ClientUtils.java
@@ -57,7 +57,7 @@ public class ClientUtils {
     private static final int JACOBS_CONTEST_START_MINUTE_UTC = 15;
     private static final int JACOBS_CONTEST_END_MINUTE_UTC = 35;
     private static final Object SIDEBAR_CACHE_LOCK = new Object();
-    private static final Pattern STRIP_SCOREBOARD_FORMATTING = Pattern.compile("(?i)\u00A7[0-9A-FK-ORZ]");
+    private static final Pattern STRIP_SCOREBOARD_FORMATTING = Pattern.compile("\u00A7.");
     private static final Pattern STRIP_MINECRAFT_FORMATTING = Pattern.compile("(?i)\u00A7[0-9A-FK-ORZ]");
     private static final DateTimeFormatter DEBUG_LOG_FILE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd-HH_mm'.txt'");
     private static final DateTimeFormatter DEBUG_LOG_LINE_TIME_FORMAT = DateTimeFormatter.ofPattern("HH:mm:ss");

--- a/src/main/java/dev/aether/util/ClientUtils.java
+++ b/src/main/java/dev/aether/util/ClientUtils.java
@@ -54,6 +54,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class ClientUtils {
+    private static final long GUI_CLOSE_STABILIZATION_MS = 250L;
+    private static final long GUI_CLOSE_POLL_MS = 25L;
     private static final int JACOBS_CONTEST_START_MINUTE_UTC = 15;
     private static final int JACOBS_CONTEST_END_MINUTE_UTC = 35;
     private static final Object SIDEBAR_CACHE_LOCK = new Object();
@@ -74,6 +76,11 @@ public class ClientUtils {
     });
     private static final ScheduledExecutorService INPUT_EXECUTOR = Executors.newSingleThreadScheduledExecutor(r -> {
         Thread thread = new Thread(r, "aether-input-dispatch");
+        thread.setDaemon(true);
+        return thread;
+    });
+    private static final ScheduledExecutorService GUI_CLOSE_EXECUTOR = Executors.newSingleThreadScheduledExecutor(r -> {
+        Thread thread = new Thread(r, "aether-gui-close");
         thread.setDaemon(true);
         return thread;
     });
@@ -250,6 +257,61 @@ public class ClientUtils {
     public static boolean isInventoryScreenOpen() {
         Minecraft client = Minecraft.getInstance();
         return client != null && client.screen instanceof AbstractContainerScreen<?>;
+    }
+
+    /**
+     * Closes the current GUI and keeps closing any GUI that reappears for the
+     * full stabilization window. Callers may rely on this method not returning
+     * before it is safe to continue with the next action.
+     */
+    public static void closeGui(Minecraft client) {
+        if (client == null) {
+            return;
+        }
+
+        long deadline = System.currentTimeMillis() + GUI_CLOSE_STABILIZATION_MS;
+        boolean interrupted = false;
+        Screen screenBeingClosed = null;
+        while (true) {
+            long remaining = deadline - System.currentTimeMillis();
+            Screen currentScreen = client.screen;
+            if (currentScreen == null) {
+                screenBeingClosed = null;
+            } else if (currentScreen != screenBeingClosed) {
+                screenBeingClosed = currentScreen;
+                Runnable closeAction = () -> {
+                    if (client.player != null && client.screen != null) {
+                        client.player.closeContainer();
+                    } else if (client.screen != null) {
+                        client.setScreen(null);
+                    }
+                };
+
+                if (client.isSameThread()) {
+                    closeAction.run();
+                } else {
+                    client.execute(closeAction);
+                }
+            }
+
+            if (remaining <= 0) {
+                break;
+            }
+
+            try {
+                Thread.sleep(Math.min(GUI_CLOSE_POLL_MS, remaining));
+            } catch (InterruptedException ignored) {
+                interrupted = true;
+            }
+        }
+
+        if (interrupted) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    public static CompletableFuture<Void> closeGuiAsync(Minecraft client) {
+        return CompletableFuture.runAsync(() -> closeGui(client), GUI_CLOSE_EXECUTOR);
     }
 
     public static void forceReleaseMovementKeys() {
@@ -846,6 +908,13 @@ public class ClientUtils {
 
     private static void scheduleClientAction(Minecraft client, long delayMs, Runnable action) {
         INPUT_EXECUTOR.schedule(() -> client.execute(action), delayMs, TimeUnit.MILLISECONDS);
+    }
+
+    public static void scheduleClientTask(Minecraft client, long delayMs, Runnable action) {
+        if (client == null || action == null) {
+            return;
+        }
+        scheduleClientAction(client, delayMs, action);
     }
 
     private static InputConstants.Key getBoundKey(KeyMapping mapping) {

--- a/src/main/java/dev/aether/util/CommandUtils.java
+++ b/src/main/java/dev/aether/util/CommandUtils.java
@@ -202,6 +202,10 @@ public class CommandUtils {
      * @return true if spawn was set successfully, false if timeout occurred
      */
     public static boolean setSpawn() {
+        return setSpawn(MESSAGE_TIMEOUT_MS);
+    }
+
+    public static boolean setSpawn(long timeoutMs) {
         if (shouldSkipSetSpawn()) {
             return true;
         }
@@ -209,7 +213,7 @@ public class CommandUtils {
         ChatWindow window = beginChatWindow();
         ClientUtils.sendCommand("/setspawn");
 
-        boolean success = waitForChatMessage(window, "Your spawn location has been set!", MESSAGE_TIMEOUT_MS);
+        boolean success = waitForChatMessage(window, "Your spawn location has been set!", timeoutMs);
 
         if (success) {
             ClientUtils.sendDebugMessage("Spawn set has been detected");

--- a/src/test/java/dev/aether/modules/pest/helpers/PestBallsackShredderTest.java
+++ b/src/test/java/dev/aether/modules/pest/helpers/PestBallsackShredderTest.java
@@ -1,0 +1,34 @@
+package dev.aether.modules.pest.helpers;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PestBallsackShredderTest {
+    @Test
+    void estimatesMultipleKillsFromTrackedEntities() {
+        PestBallsackShredder.Result result =
+                PestBallsackShredder.estimateResult(8, 8, 8);
+
+        assertEquals(8, result.estimatedKilled());
+        assertEquals(0, result.estimatedRemaining());
+    }
+
+    @Test
+    void usesFreshTabDropWhenItDetectsMoreKills() {
+        PestBallsackShredder.Result result =
+                PestBallsackShredder.estimateResult(8, 3, 1);
+
+        assertEquals(7, result.estimatedKilled());
+        assertEquals(1, result.estimatedRemaining());
+    }
+
+    @Test
+    void treatsMissingPestTabLineAsNoPestsRemaining() {
+        PestBallsackShredder.Result result =
+                PestBallsackShredder.estimateResult(5, 4, -1);
+
+        assertEquals(5, result.estimatedKilled());
+        assertEquals(0, result.estimatedRemaining());
+    }
+}

--- a/src/test/java/dev/aether/modules/pest/helpers/PestDestroyerRuntimeTest.java
+++ b/src/test/java/dev/aether/modules/pest/helpers/PestDestroyerRuntimeTest.java
@@ -40,4 +40,16 @@ class PestDestroyerRuntimeTest {
         assertEquals(0, runtime.zeroPestTabTicks);
         assertTrue(runtime.navigation.plotQueue.isEmpty());
     }
+
+    @Test
+    void claimsMultipleKilledPestsOncePerEntity() {
+        PestDestroyerRuntime runtime = new PestDestroyerRuntime();
+
+        assertTrue(runtime.claimKilledPestEntityId(10));
+        assertTrue(runtime.claimKilledPestEntityId(11));
+        assertTrue(runtime.claimKilledPestEntityId(12));
+        assertFalse(runtime.claimKilledPestEntityId(10));
+        assertFalse(runtime.claimKilledPestEntityId(12));
+        assertEquals(3, runtime.accountedKilledPestEntityIds.size());
+    }
 }

--- a/src/test/java/dev/aether/modules/pest/helpers/PestLeaveOneControllerTest.java
+++ b/src/test/java/dev/aether/modules/pest/helpers/PestLeaveOneControllerTest.java
@@ -1,0 +1,31 @@
+package dev.aether.modules.pest.helpers;
+
+import org.junit.jupiter.api.Test;
+import net.minecraft.world.phys.Vec3;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PestLeaveOneControllerTest {
+    @Test
+    void parsesCurrentPlotCountAndOnlyFinishesForRememberedPlots() {
+        List<String> sidebar = List.of("The Garden x6", "Plot - 15 x4");
+
+        assertEquals(4, PestLeaveOneController.parsePlotPestCount(sidebar, "15"));
+        assertEquals(-1, PestLeaveOneController.parsePlotPestCount(sidebar, "17"));
+        assertFalse(PestLeaveOneController.shouldFinishForCounts(1, 0));
+        assertFalse(PestLeaveOneController.shouldFinishForCounts(2, 1));
+        assertTrue(PestLeaveOneController.shouldFinishForCounts(2, 2));
+        assertEquals(5, PestLeaveOneController.killBudgetForCount(6));
+        assertEquals(4, PestLeaveOneController.consumeKillBudget(5));
+        assertEquals(0, PestLeaveOneController.consumeKillBudget(0));
+        assertEquals(2, PestLeaveOneController.remainingKillBudget(4, 1));
+        assertEquals(2, PestTargetTracker.mostIsolatedIndex(List.of(
+                new Vec3(0, 0, 0),
+                new Vec3(1, 0, 0),
+                new Vec3(10, 0, 0))));
+    }
+}

--- a/src/test/java/dev/aether/modules/pest/helpers/PestLifecycleManagerTest.java
+++ b/src/test/java/dev/aether/modules/pest/helpers/PestLifecycleManagerTest.java
@@ -1,0 +1,22 @@
+package dev.aether.modules.pest.helpers;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PestLifecycleManagerTest {
+    @Test
+    void retriesSetSpawnOnlyWhileThePendingFarmingSessionIsValid() {
+        assertEquals(2, PestLifecycleManager.SETSPAWN_MAX_ATTEMPTS);
+        assertTrue(PestLifecycleManager.shouldRetrySetSpawn(
+                PestLifecycleManager.Stage.PRE, 4, 4, false, false));
+        assertFalse(PestLifecycleManager.shouldRetrySetSpawn(
+                PestLifecycleManager.Stage.PRE, 4, 5, false, false));
+        assertFalse(PestLifecycleManager.shouldRetrySetSpawn(
+                PestLifecycleManager.Stage.PRE, 4, 4, true, false));
+        assertFalse(PestLifecycleManager.shouldRetrySetSpawn(
+                PestLifecycleManager.Stage.PRE, 4, 4, false, true));
+    }
+}

--- a/src/test/java/dev/aether/modules/pest/helpers/PestLifecycleManagerTest.java
+++ b/src/test/java/dev/aether/modules/pest/helpers/PestLifecycleManagerTest.java
@@ -19,4 +19,19 @@ class PestLifecycleManagerTest {
         assertFalse(PestLifecycleManager.shouldRetrySetSpawn(
                 PestLifecycleManager.Stage.PRE, 4, 4, false, true));
     }
+
+    @Test
+    void skipsDestroyerWhenBallsackLeavesOneOnTheTargetLeaveOnePlot() {
+        assertTrue(PestLifecycleManager.shouldSkipCleaningAfterBallsack(1, true, false));
+    }
+
+    @Test
+    void doesNotSkipDestroyerForOnePestOnANonLeaveOnePlot() {
+        assertFalse(PestLifecycleManager.shouldSkipCleaningAfterBallsack(1, false, false));
+    }
+
+    @Test
+    void skipsDestroyerWhenBallsackKillsEveryPest() {
+        assertTrue(PestLifecycleManager.shouldSkipCleaningAfterBallsack(0, false, false));
+    }
 }


### PR DESCRIPTION
- add ballsack shredder support (#82)
- fixed rare case where double GUI opens would interfere with macro (#82)
- retargets if we accidentally hit a close by visitor (#82)
- continue farming and retries later if we fail to /setspawn (#83)
- improved Leave One Pest Alive to work with multiple plots better (#84)