### PR TITLE
re-equip farming armor

### DIFF
--- a/src/main/java/dev/aether/modules/pest/PestManager.java
+++ b/src/main/java/dev/aether/modules/pest/PestManager.java
@@ -234,10 +234,11 @@ public class PestManager {
 
         // Handle prep swap flag updates based on cooldown
         if (data.cooldownSeconds() != -1) {
-                PestPrepSwapManager.updatePrepSwapFlag(data.cooldownSeconds(), isCleaningInProgress);
+            boolean thresholdMet = isThresholdMet(effectiveAlive);
+            PestPrepSwapManager.updatePrepSwapFlag(
+                    data.cooldownSeconds(), isCleaningInProgress, thresholdMet);
 
             // Check if prep swap should be triggered
-            boolean thresholdMet = isThresholdMet(effectiveAlive);
             if (!thresholdMet && PestPrepSwapManager.shouldTriggerPrepSwap(
                     currentState, data.cooldownSeconds(), isCleaningInProgress,
                     PestReturnManager.isReturnToLocationActive())) {

--- a/src/main/java/dev/aether/modules/pest/helpers/PestPrepSwapManager.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestPrepSwapManager.java
@@ -36,11 +36,16 @@ public class PestPrepSwapManager {
         return Minecraft.getInstance();
     }
 
-    public static void updatePrepSwapFlag(int cooldownSeconds, boolean isCleaningInProgress) {
+    public static void updatePrepSwapFlag(int cooldownSeconds, boolean isCleaningInProgress,
+            boolean thresholdMet) {
         if (cooldownSeconds > getPrepSwapResetCooldownSeconds()
                 && prepSwappedForCurrentPestCycle
                 && !isCleaningInProgress) {
-            prepSwappedForCurrentPestCycle = false;
+            if (thresholdMet) {
+                prepSwappedForCurrentPestCycle = false;
+            } else {
+                restoreFarmingLoadout();
+            }
         }
     }
 
@@ -93,6 +98,43 @@ public class PestPrepSwapManager {
 
     private static int getPrepSwapResetCooldownSeconds() {
         return AetherConfig.LOADOUT_PEST_SWAP_TIME_SECONDS.get();
+    }
+
+    private static void restoreFarmingLoadout() {
+        if (isPrepSwapping) {
+            return;
+        }
+
+        isPrepSwapping = true;
+        ClientUtils.sendDebugMessage("Pest spawn stayed below threshold. Restoring farming loadout...");
+        MacroWorkerThread.getInstance().submit("PrepSwap-RestoreFarming", () -> {
+            try {
+                Minecraft client = client();
+                if (MacroWorkerThread.shouldAbortTask(client, MacroState.State.FARMING)
+                        || PestManager.isCleaningInProgress()) {
+                    return;
+                }
+
+                client.execute(() -> dev.aether.macro.farming.FarmingMacroManager.disable(client));
+                MacroWorkerThread.sleep(400);
+                if (MacroWorkerThread.shouldAbortTask(client, MacroState.State.FARMING)
+                        || PestManager.isCleaningInProgress()) {
+                    return;
+                }
+
+                if (PestReturnManager.restoreFarmingLoadout(client)
+                        && !PestManager.isCleaningInProgress()) {
+                    GearManager.finalResume(client);
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+            } finally {
+                if (!PestManager.isCleaningInProgress()) {
+                    prepSwappedForCurrentPestCycle = false;
+                }
+                isPrepSwapping = false;
+            }
+        });
     }
 
     private static boolean shouldAbortPrepSwap() {

--- a/src/main/java/dev/aether/modules/pest/helpers/PestReturnManager.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestReturnManager.java
@@ -390,7 +390,7 @@ public class PestReturnManager {
         }
     }
 
-    private static boolean restoreFarmingLoadout(Minecraft client) throws InterruptedException {
+    static boolean restoreFarmingLoadout(Minecraft client) throws InterruptedException {
         int targetSlot = AetherConfig.LOADOUT_SLOT_FARMING.get();
         if (targetSlot <= 0 || LoadoutManager.trackedLoadoutSlot == targetSlot) {
             return true;


### PR DESCRIPTION
fixes it so that if a user spawns less pests than their pest threshold it will re-equip their farming loadout instead of staying in the pest spawning loadout until the next spawn