### PR TITLE
feat: add pest estimate toggle

### DIFF
--- a/src/main/java/dev/aether/config/AetherConfig.java
+++ b/src/main/java/dev/aether/config/AetherConfig.java
@@ -448,6 +448,7 @@ public final class AetherConfig {
                         Collections.emptyList(), String.class);
         public static final BooleanEntry SUNSET_PESTS = Config.bool("sunsetPests", false);
         public static final BooleanEntry BALLSACK_SHREDDER = Config.bool("ballsackShredder", false);
+        public static final IntEntry BALLSACK_WARPS = Config.integer("ballsackWarps", 2).range(1, 5);
         public static final IntEntry BALLSACK_LOOK_DOWN_TIME_MS = Config.integer("ballsackLookDownTimeMs", 1000)
                         .range(0, 3000);
         public static final BooleanEntry PEST_AOTV_BETWEEN = Config.bool("pestAotvBetween", false);

--- a/src/main/java/dev/aether/config/AetherConfig.java
+++ b/src/main/java/dev/aether/config/AetherConfig.java
@@ -415,6 +415,8 @@ public final class AetherConfig {
 
         public static final IntEntry PEST_THRESHOLD = Config.integer("pestThreshold", 2).range(1, 8);
         public static final BooleanEntry TRIGGER_PEST_ON_CHAT = Config.bool("triggerPestOnChat", true);
+        public static final BooleanEntry ESTIMATE_PEST_DESTROYER_COMPLETION =
+                        Config.bool("estimatePestDestroyerCompletion", true);
         public static final BooleanEntry PEST_TRIGGER_ONLY_AFTER_REWARP = Config.bool("pestTriggerOnlyAfterRewarp", false);
         public static final IntEntry PEST_CHAT_TRIGGER_DELAY_MIN = Config.integer("pestChatTriggerDelayMin", 500)
                         .range(0, 30000);

--- a/src/main/java/dev/aether/modules/pest/PestManager.java
+++ b/src/main/java/dev/aether/modules/pest/PestManager.java
@@ -251,8 +251,12 @@ public class PestManager {
         if (currentState == MacroState.State.CLEANING
                 && !GreenhouseManager.isRunning()
                 && !ManualPestManager.isActive()) {
-            updateCleaningProgressTracker(effectiveAlive);
-            if (effectiveAlive <= 0) {
+            int completionAlive = selectCompletionAliveCount(
+                    AetherConfig.ESTIMATE_PEST_DESTROYER_COMPLETION.get(),
+                    data.aliveCount(),
+                    effectiveAlive);
+            updateCleaningProgressTracker(completionAlive);
+            if (completionAlive <= 0) {
                 if (lastZeroPestTime == 0) {
                     lastZeroPestTime = System.currentTimeMillis();
                 } else if (System.currentTimeMillis() - lastZeroPestTime > 10000) {
@@ -265,11 +269,11 @@ public class PestManager {
                 lastZeroPestTime = 0;
             }
 
-            if (shouldAbortCleaningForStall(effectiveAlive)) {
+            if (shouldAbortCleaningForStall(completionAlive)) {
                 ClientUtils.sendMessage("\u00A7cPest cleaner made no pest-count progress for 30s. Aborting cleaner.",
                         true);
                 ClientUtils.sendDebugMessage("PestManager: aborting pest cleaner after 30s without alive-count progress. Last alive="
-                                + lastCleaningAliveCount + ", current alive=" + effectiveAlive);
+                                + lastCleaningAliveCount + ", current alive=" + completionAlive);
                 resetCleaningProgressTracker();
                 handlePestCleaningFinished(client);
                 return;
@@ -430,6 +434,24 @@ public class PestManager {
         return getEffectiveAliveCount(data.aliveCount());
     }
 
+    /**
+     * Count used only to decide whether Pest Destroyer is complete. When
+     * estimation is disabled, a missing pests line is treated as the tab
+     * reporting zero pests after the destroyer's normal confirmation guard.
+     */
+    public static int getPestDestroyerCompletionAliveCountNow(Minecraft client) {
+        if (client == null || client.getConnection() == null || client.player == null) {
+            return -1;
+        }
+
+        PestTabSnapshot data = parseTabList(client);
+        if (!AetherConfig.ESTIMATE_PEST_DESTROYER_COMPLETION.get()) {
+            return Math.max(0, data.aliveCount());
+        }
+        syncPredictedAliveFromTab(data.aliveCount());
+        return getEffectiveAliveCount(data.aliveCount());
+    }
+
     public static boolean startCleaningSequence(Minecraft client, String plot) {
         return startCleaningSequence(client, plot, Math.max(1, getEffectiveAliveCountNow(client)));
     }
@@ -533,7 +555,9 @@ public class PestManager {
                             + ", currentPlot=" + ClientUtils.getCurrentPlot()
                             + ", whitelistedPlots=" + AetherConfig.LEAVE_ONE_PEST_PLOTS.get());
 
-            if (PestDestroyer.isActive() && PestDestroyer.shouldFinishForAliveCount(client, predictedAliveCount)) {
+            if (AetherConfig.ESTIMATE_PEST_DESTROYER_COMPLETION.get()
+                    && PestDestroyer.isActive()
+                    && PestDestroyer.shouldFinishForAliveCount(client, predictedAliveCount)) {
                 String reason = predictedAliveCount == 0
                         ? "0 pests predicted"
                         : "only whitelisted leave-one plot(s) predicted remaining";
@@ -571,6 +595,13 @@ public class PestManager {
             return predictedAliveCount;
         }
         return Math.max(tabAliveCount, predictedAliveCount);
+    }
+
+    static int selectCompletionAliveCount(
+            boolean estimateCompletion,
+            int tabAliveCount,
+            int effectiveAliveCount) {
+        return estimateCompletion ? effectiveAliveCount : Math.max(0, tabAliveCount);
     }
 
     private static boolean hasRecentLocalKill(long now) {

--- a/src/main/java/dev/aether/modules/pest/helpers/PestBallsackShredder.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestBallsackShredder.java
@@ -47,14 +47,16 @@ final class PestBallsackShredder {
             ClientUtils.setKeyMappingState(client.options.keyUse, true);
         });
 
-        int positionChanges = waitForPositionChanges(client, sessionId);
+        int requiredWarps = AetherConfig.BALLSACK_WARPS.get();
+        int positionChanges = waitForPositionChanges(client, sessionId, requiredWarps);
         releaseAotvKeys(client);
         if (shouldAbort(client, sessionId)) {
             return Result.unmeasured(false, startingPests);
         }
-        if (positionChanges < 2) {
+        if (positionChanges < requiredWarps) {
             ClientUtils.sendDebugMessage("Ballsack Shredder: AOTV timed out after "
-                    + positionChanges + " position change(s); continuing pest cleaning.");
+                    + positionChanges + " of " + requiredWarps
+                    + " position change(s); continuing pest cleaning.");
             return Result.unmeasured(true, startingPests);
         }
 
@@ -130,7 +132,8 @@ final class PestBallsackShredder {
         return new Result(true, true, estimatedKilled, normalizedStart - estimatedKilled);
     }
 
-    private static int waitForPositionChanges(Minecraft client, int sessionId) throws InterruptedException {
+    private static int waitForPositionChanges(Minecraft client, int sessionId, int requiredWarps)
+            throws InterruptedException {
         Vec3 lastPosition = PestClientThread.call(client, () -> client.player.position(), null);
         if (lastPosition == null) {
             return 0;
@@ -138,7 +141,9 @@ final class PestBallsackShredder {
 
         int changes = 0;
         long deadline = System.currentTimeMillis() + AOTV_TIMEOUT_MS;
-        while (changes < 2 && System.currentTimeMillis() < deadline && !shouldAbort(client, sessionId)) {
+        while (changes < requiredWarps
+                && System.currentTimeMillis() < deadline
+                && !shouldAbort(client, sessionId)) {
             MacroWorkerThread.sleep(25);
             Vec3 previousPosition = lastPosition;
             Vec3 currentPosition = PestClientThread.call(client, () -> client.player.position(), previousPosition);

--- a/src/main/java/dev/aether/modules/pest/helpers/PestDestroyerProgressController.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestDestroyerProgressController.java
@@ -36,7 +36,7 @@ final class PestDestroyerProgressController {
             PestDestroyerRuntime runtime,
             long stuckTimeoutMs,
             Context context) {
-        int aliveNow = PestManager.getEffectiveAliveCountNow(client);
+        int aliveNow = PestManager.getPestDestroyerCompletionAliveCountNow(client);
         boolean finishReading = aliveNow >= 0
                 && context.shouldFinishForAliveCount(client, aliveNow);
 

--- a/src/main/java/dev/aether/ui/providers/modules/PestManagerRegistryProvider.java
+++ b/src/main/java/dev/aether/ui/providers/modules/PestManagerRegistryProvider.java
@@ -145,6 +145,13 @@ public final class PestManagerRegistryProvider extends AbstractModulesRegistryPr
                             AetherConfig.BALLSACK_SHREDDER.set(v);
                             AetherConfig.save();
                         })
+                .add(new SliderSetting("AOTV Warps", 1, 5,
+                        () -> (float) AetherConfig.BALLSACK_WARPS.get(),
+                        v -> {
+                            AetherConfig.BALLSACK_WARPS.set(Math.round(v));
+                            AetherConfig.save();
+                        })
+                        .withDecimals(0))
                 .add(FarmingSettingsFactory.pestDestroyerTriggerDelaySetting())
                 .add(new SliderSetting("Look Down Time", 0, 3000,
                         () -> (float) AetherConfig.BALLSACK_LOOK_DOWN_TIME_MS.get(),

--- a/src/main/java/dev/aether/ui/providers/modules/PestManagerRegistryProvider.java
+++ b/src/main/java/dev/aether/ui/providers/modules/PestManagerRegistryProvider.java
@@ -83,6 +83,12 @@ public final class PestManagerRegistryProvider extends AbstractModulesRegistryPr
                             AetherConfig.save();
                         })
                         .withDecimals(0))
+                .add(new ToggleSetting("Estimate Pest Destroyer Completion",
+                        AetherConfig.ESTIMATE_PEST_DESTROYER_COMPLETION::get,
+                        v -> {
+                            AetherConfig.ESTIMATE_PEST_DESTROYER_COMPLETION.set(v);
+                            AetherConfig.save();
+                        }))
                 .add(new ToggleSetting("Skip while Crop Fever Active",
                         () -> AetherConfig.DELAY_PEST_FOR_CROP_FEVER.get(),
                         v -> {

--- a/src/main/resources/assets/aether/lang/en_us.json
+++ b/src/main/resources/assets/aether/lang/en_us.json
@@ -257,6 +257,7 @@
   "text.aether.inventory_full_time": "Inventory Full Time",
   "text.aether.inventory_hud": "Inventory HUD",
   "text.aether.inventory_threshold": "Inventory Threshold",
+  "text.aether.estimate_pest_destroyer_completion": "Estimate Pest Destroyer Completion",
   "text.aether.npc_shop_coin_limit_reached_autosell_disabled": "NPC shop coin limit reached. AutoSell disabled.",
   "text.aether.items": "Items",
   "text.aether.junk_items": "Junk Items",

--- a/src/test/java/dev/aether/modules/pest/PestManagerCompletionTest.java
+++ b/src/test/java/dev/aether/modules/pest/PestManagerCompletionTest.java
@@ -1,0 +1,18 @@
+package dev.aether.modules.pest;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PestManagerCompletionTest {
+    @Test
+    void estimatedCompletionUsesEffectiveCount() {
+        assertEquals(3, PestManager.selectCompletionAliveCount(true, 6, 3));
+    }
+
+    @Test
+    void tabOnlyCompletionIgnoresEstimate() {
+        assertEquals(6, PestManager.selectCompletionAliveCount(false, 6, 3));
+        assertEquals(0, PestManager.selectCompletionAliveCount(false, -1, 3));
+    }
+}


### PR DESCRIPTION
Allows users to turn off Pest Destroyer Estimate (default is on). When this is off, it will only go off of tab readings for whether all pests are killed.