### PR TITLE
feat: add configurable options for ballsack shredder

### DIFF
--- a/src/main/java/dev/aether/config/AetherConfig.java
+++ b/src/main/java/dev/aether/config/AetherConfig.java
@@ -448,6 +448,7 @@ public final class AetherConfig {
                         Collections.emptyList(), String.class);
         public static final BooleanEntry SUNSET_PESTS = Config.bool("sunsetPests", false);
         public static final BooleanEntry BALLSACK_SHREDDER = Config.bool("ballsackShredder", false);
+        public static final IntEntry BALLSACK_WARPS = Config.integer("ballsackWarps", 2).range(1, 5);
         public static final IntEntry BALLSACK_LOOK_DOWN_TIME_MS = Config.integer("ballsackLookDownTimeMs", 1000)
                         .range(0, 3000);
         public static final BooleanEntry PEST_AOTV_BETWEEN = Config.bool("pestAotvBetween", false);

--- a/src/main/java/dev/aether/config/AetherConfig.java
+++ b/src/main/java/dev/aether/config/AetherConfig.java
@@ -448,6 +448,8 @@ public final class AetherConfig {
                         Collections.emptyList(), String.class);
         public static final BooleanEntry SUNSET_PESTS = Config.bool("sunsetPests", false);
         public static final BooleanEntry BALLSACK_SHREDDER = Config.bool("ballsackShredder", false);
+        public static final ListEntry<String> BALLSACK_SHREDDER_PLOTS = Config.list("ballsackShredderPlots",
+                        Collections.emptyList(), String.class);
         public static final IntEntry BALLSACK_WARPS = Config.integer("ballsackWarps", 2).range(1, 5);
         public static final IntEntry BALLSACK_LOOK_DOWN_TIME_MS = Config.integer("ballsackLookDownTimeMs", 1000)
                         .range(0, 3000);

--- a/src/main/java/dev/aether/modules/pest/helpers/PestAotvManager.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestAotvManager.java
@@ -101,7 +101,7 @@ public class PestAotvManager {
     }
 
     public static boolean shouldDoAotvOnCurrentPlot(Minecraft client, String currentInfestedPlot, boolean isSamePlot) {
-        if (AetherConfig.BALLSACK_SHREDDER.get() || !AetherConfig.AOTV_TO_ROOF.get())
+        if (PestBallsackShredder.shouldRunOnPlot(currentInfestedPlot) || !AetherConfig.AOTV_TO_ROOF.get())
             return false;
 
         if (AetherConfig.AOTV_ROOF_PLOTS.get().isEmpty())
@@ -250,13 +250,17 @@ public class PestAotvManager {
 
     /** Performs the post-roof view reset on the worker after its AOTV phase has ended. */
     public static void rotateDownAfterAotv(Minecraft client) throws InterruptedException {
+        rotateDownAfterAotv(client, false);
+    }
+
+    public static void rotateDownAfterAotv(Minecraft client, boolean ballsackOnPlot) throws InterruptedException {
         if (client == null || client.player == null) {
             return;
         }
 
         float targetYaw = PestClientThread.call(
                 client, () -> client.player.getYRot() + randomYawOffset(), 0.0f);
-        float targetPitch = AetherConfig.BALLSACK_SHREDDER.get()
+        float targetPitch = ballsackOnPlot
                 ? 90.0f
                 : (float) (-30.0 + Math.random() * 60.0);
         int rotTime = (int) (AetherConfig.ROTATION_TIME.get() * (0.92 + Math.random() * 0.16));
@@ -277,7 +281,7 @@ public class PestAotvManager {
             MacroWorkerThread.sleep(20);
         }
 
-        if (AetherConfig.BALLSACK_SHREDDER.get()) {
+        if (ballsackOnPlot) {
             int vacuumSlot = PestLoadoutHelper.findVacuumHotbarSlot(client);
             if (vacuumSlot >= 0 && vacuumSlot < 9) {
                 PestClientThread.run(client, () -> {

--- a/src/main/java/dev/aether/modules/pest/helpers/PestBallsackShredder.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestBallsackShredder.java
@@ -47,14 +47,16 @@ final class PestBallsackShredder {
             ClientUtils.setKeyMappingState(client.options.keyUse, true);
         });
 
-        int positionChanges = waitForPositionChanges(client, sessionId);
+        int requiredWarps = AetherConfig.BALLSACK_WARPS.get();
+        int positionChanges = waitForPositionChanges(client, sessionId, requiredWarps);
         releaseAotvKeys(client);
         if (shouldAbort(client, sessionId)) {
             return Result.unmeasured(false, startingPests);
         }
-        if (positionChanges < 2) {
+        if (positionChanges < requiredWarps) {
             ClientUtils.sendDebugMessage("Ballsack Shredder: AOTV timed out after "
-                    + positionChanges + " position change(s); continuing pest cleaning.");
+                    + positionChanges + " of " + requiredWarps
+                    + " position change(s); continuing pest cleaning.");
             return Result.unmeasured(true, startingPests);
         }
 
@@ -130,7 +132,8 @@ final class PestBallsackShredder {
         return new Result(true, true, estimatedKilled, normalizedStart - estimatedKilled);
     }
 
-    private static int waitForPositionChanges(Minecraft client, int sessionId) throws InterruptedException {
+    private static int waitForPositionChanges(Minecraft client, int sessionId, int requiredWarps)
+            throws InterruptedException {
         Vec3 lastPosition = PestClientThread.call(client, () -> client.player.position(), null);
         if (lastPosition == null) {
             return 0;
@@ -138,7 +141,9 @@ final class PestBallsackShredder {
 
         int changes = 0;
         long deadline = System.currentTimeMillis() + AOTV_TIMEOUT_MS;
-        while (changes < 2 && System.currentTimeMillis() < deadline && !shouldAbort(client, sessionId)) {
+        while (changes < requiredWarps
+                && System.currentTimeMillis() < deadline
+                && !shouldAbort(client, sessionId)) {
             MacroWorkerThread.sleep(25);
             Vec3 previousPosition = lastPosition;
             Vec3 currentPosition = PestClientThread.call(client, () -> client.player.position(), previousPosition);

--- a/src/main/java/dev/aether/modules/pest/helpers/PestBallsackShredder.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestBallsackShredder.java
@@ -87,6 +87,18 @@ final class PestBallsackShredder {
         return result;
     }
 
+    static boolean shouldRunOnPlot(String plot) {
+        return AetherConfig.BALLSACK_SHREDDER.get()
+                && isConfiguredForPlot(plot, AetherConfig.BALLSACK_SHREDDER_PLOTS.get());
+    }
+
+    static boolean isConfiguredForPlot(String plot, List<String> configuredPlots) {
+        if (configuredPlots == null || configuredPlots.isEmpty()) {
+            return true;
+        }
+        return configuredPlots.stream().anyMatch(configuredPlot -> PestPlotId.equals(configuredPlot, plot));
+    }
+
     private static Result awaitResultEvidence(
             Minecraft client,
             int sessionId,

--- a/src/main/java/dev/aether/modules/pest/helpers/PestPreStage.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestPreStage.java
@@ -47,7 +47,8 @@ final class PestPreStage {
             return Result.failure();
         }
 
-        if (AetherConfig.BALLSACK_SHREDDER.get()) {
+        boolean ballsackOnPlot = PestBallsackShredder.shouldRunOnPlot(plot);
+        if (ballsackOnPlot) {
             PestBallsackShredder.Result result =
                     PestBallsackShredder.run(client, sessionId, pestCount);
             return new Result(result.successful(), result);
@@ -72,7 +73,8 @@ final class PestPreStage {
         }
 
         boolean forcePlotTp =
-                alreadyOnPlot && (AetherConfig.PEST_PLOT_TP_FOR_CURRENT_PLOT.get() || AetherConfig.BALLSACK_SHREDDER.get());
+                alreadyOnPlot && (AetherConfig.PEST_PLOT_TP_FOR_CURRENT_PLOT.get()
+                        || PestBallsackShredder.shouldRunOnPlot(plot));
 
         if (alreadyOnPlot && !forcePlotTp) {
             String source = chatMatch ? "chat" : "scoreboard";
@@ -109,7 +111,7 @@ final class PestPreStage {
             CommandUtils.initiatePlotTp(plot);
             MacroWorkerThread.sleep(2500);
         } else {
-            PestAotvManager.rotateDownAfterAotv(client);
+            PestAotvManager.rotateDownAfterAotv(client, PestBallsackShredder.shouldRunOnPlot(plot));
         }
         return !shouldAbort(client, sessionId);
     }

--- a/src/main/java/dev/aether/modules/pest/helpers/PestRoofAotvController.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestRoofAotvController.java
@@ -54,12 +54,13 @@ final class PestRoofAotvController {
         runtime.aotvStartY = Double.NaN;
         releaseAotvKeys(client);
         float targetYaw = client.player.getYRot() + (float) (-10.0 + Math.random() * 20.0);
-        float targetPitch = AetherConfig.BALLSACK_SHREDDER.get()
+        boolean ballsackOnPlot = PestBallsackShredder.shouldRunOnPlot(ClientUtils.getCurrentPlot());
+        float targetPitch = ballsackOnPlot
                 ? 90.0f
                 : (float) (-30.0 + Math.random() * 60.0);
         RotationManager.rotateToYawPitch(
                 client, targetYaw, targetPitch, AetherConfig.ROTATION_TIME.get(), true);
-        if (AetherConfig.BALLSACK_SHREDDER.get()) {
+        if (ballsackOnPlot) {
             PestAotvManager.setSneakingForAotv(false);
             PestDestroyer.setState(PestDestroyer.State.AOTV_POST_LOOKDOWN);
         } else {

--- a/src/main/java/dev/aether/modules/session/RecoveryManager.java
+++ b/src/main/java/dev/aether/modules/session/RecoveryManager.java
@@ -44,7 +44,7 @@ public class RecoveryManager {
         }
     }
 
-    private static final long RECOVERY_COMMAND_DELAY_MS = 10_000L;
+    private static final long RECOVERY_COMMAND_DELAY_MS = 3_000L;
     private static final long WORLD_CHANGE_ALIGN_TIMEOUT_MS = 1200L;
     private static final long WORLD_CHANGE_RESUME_DELAY_MS = 1000L;
     private static int recoveryFailedAttempts = 0;
@@ -80,14 +80,14 @@ public class RecoveryManager {
     public static void beginRecovery() {
         reset();
         beginCommandSequence(RecoveryCommandStage.SKYBLOCK);
-        ClientUtils.sendMessage("\u00A7eRecovery: waiting 10 seconds before /skyblock...", false);
+        ClientUtils.sendMessage("\u00A7eRecovery: waiting 3 seconds before /skyblock...", false);
     }
 
     public static void beginLimboRecovery() {
         reset();
         recoveryMode = RecoveryMode.LIMBO;
         beginCommandSequence(RecoveryCommandStage.LOBBY);
-        ClientUtils.sendMessage("\u00A7eLimbo recovery: waiting 10 seconds before /lobby...", false);
+        ClientUtils.sendMessage("\u00A7eLimbo recovery: waiting 3 seconds before /lobby...", false);
     }
 
     public static void beginWorldChangeRecovery(Vec3 savedPosition) {
@@ -181,7 +181,7 @@ public class RecoveryManager {
         recoveryCommandFailed = false;
         lastRecoveryCommandTime = now;
         ClientUtils.sendMessage("\u00A7eRecovery: running " + recoveryCommandStage.command
-                + ", waiting 10 seconds for a response...", false);
+                + ", waiting 3 seconds for a response...", false);
         ClientUtils.sendCommand(recoveryCommandStage.command);
     }
 

--- a/src/main/java/dev/aether/modules/session/RestartManager.java
+++ b/src/main/java/dev/aether/modules/session/RestartManager.java
@@ -205,6 +205,7 @@ public class RestartManager {
         } else if (restartSequenceStage == 2 && System.currentTimeMillis() >= nextRestartActionTime) {
             ClientUtils.sendDebugMessage("Disabling farming macro: Entering recovery mode after server restart");
             client.execute(() -> dev.aether.macro.farming.FarmingMacroManager.disable(client));
+            RecoveryManager.beginRecovery();
             MacroStateManager.setCurrentState(MacroState.State.RECOVERING);
             restartSequenceStage = 0;
             isRestartPending = false;

--- a/src/main/java/dev/aether/ui/providers/modules/PestManagerRegistryProvider.java
+++ b/src/main/java/dev/aether/ui/providers/modules/PestManagerRegistryProvider.java
@@ -145,6 +145,13 @@ public final class PestManagerRegistryProvider extends AbstractModulesRegistryPr
                             AetherConfig.BALLSACK_SHREDDER.set(v);
                             AetherConfig.save();
                         })
+                .add(new SliderSetting("AOTV Warps", 1, 5,
+                        () -> (float) AetherConfig.BALLSACK_WARPS.get(),
+                        v -> {
+                            AetherConfig.BALLSACK_WARPS.set(Math.round(v));
+                            AetherConfig.save();
+                        })
+                        .withDecimals(0))
                 .add(FarmingSettingsFactory.pestDestroyerTriggerDelaySetting())
                 .add(new SliderSetting("Look Down Time", 0, 3000,
                         () -> (float) AetherConfig.BALLSACK_LOOK_DOWN_TIME_MS.get(),

--- a/src/main/java/dev/aether/ui/providers/modules/PestManagerRegistryProvider.java
+++ b/src/main/java/dev/aether/ui/providers/modules/PestManagerRegistryProvider.java
@@ -145,6 +145,13 @@ public final class PestManagerRegistryProvider extends AbstractModulesRegistryPr
                             AetherConfig.BALLSACK_SHREDDER.set(v);
                             AetherConfig.save();
                         })
+                .add(new ListSetting("Ballsack Shredder Plots", "Add plot number",
+                        () -> AetherConfig.BALLSACK_SHREDDER_PLOTS.get(),
+                        v -> {
+                            AetherConfig.BALLSACK_SHREDDER_PLOTS.set(v);
+                            AetherConfig.save();
+                        })
+                        .visibleWhen(AetherConfig.BALLSACK_SHREDDER::get))
                 .add(new SliderSetting("AOTV Warps", 1, 5,
                         () -> (float) AetherConfig.BALLSACK_WARPS.get(),
                         v -> {

--- a/src/test/java/dev/aether/modules/pest/helpers/PestBallsackShredderTest.java
+++ b/src/test/java/dev/aether/modules/pest/helpers/PestBallsackShredderTest.java
@@ -2,9 +2,25 @@ package dev.aether.modules.pest.helpers;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PestBallsackShredderTest {
+    @Test
+    void emptyPlotListAppliesToEveryPlot() {
+        assertTrue(PestBallsackShredder.isConfiguredForPlot("17", List.of()));
+        assertTrue(PestBallsackShredder.isConfiguredForPlot("unknown", List.of()));
+    }
+
+    @Test
+    void configuredPlotListOnlyAppliesToListedPlots() {
+        assertTrue(PestBallsackShredder.isConfiguredForPlot("Plot 17", List.of("17")));
+        assertFalse(PestBallsackShredder.isConfiguredForPlot("18", List.of("17")));
+    }
+
     @Test
     void estimatesMultipleKillsFromTrackedEntities() {
         PestBallsackShredder.Result result =


### PR DESCRIPTION
- add configurable number of warps. By default, 2 warps are needed, but users can choose between 1 to 5.
- add configurable list of ballsack shredder plots. takes precedence over AOTV to roof plots
- fixed recovery sequence
