### PR TITLE
fix: confirm loadout swap was successful before closing

### DIFF
--- a/src/main/java/dev/aether/bootstrap/AetherChatEvents.java
+++ b/src/main/java/dev/aether/bootstrap/AetherChatEvents.java
@@ -7,6 +7,7 @@ import dev.aether.macro.MacroStateManager;
 import dev.aether.macro.MacroWorkerThread;
 import dev.aether.modules.CropFeverManager;
 import dev.aether.modules.farming.BedrockPlotMaker;
+import dev.aether.modules.gear.helpers.LoadoutManager;
 import dev.aether.modules.metaldetector.MetalDetectorSolver;
 import dev.aether.modules.misc.AutoCarnivalManager;
 import dev.aether.modules.pest.PestManager;
@@ -62,6 +63,8 @@ public final class AetherChatEvents {
             if (overlay || isHandlingMessage) {
                 return;
             }
+
+            LoadoutManager.onChatMessage(plainText);
 
             RecoveryManager.handleRecoveryCommandSuccess(lowerPlainText);
             RecoveryManager.handleRecoveryCommandFailure(lowerPlainText);

--- a/src/main/java/dev/aether/modules/gear/helpers/LoadoutManager.java
+++ b/src/main/java/dev/aether/modules/gear/helpers/LoadoutManager.java
@@ -15,6 +15,8 @@ import net.minecraft.world.inventory.ContainerInput;
 import net.minecraft.world.inventory.Slot;
 
 public class LoadoutManager {
+    private static final long LOADOUT_CHAT_RETRY_DELAY_MS = 500L;
+
     public static volatile boolean isSwappingLoadout = false;
     public static volatile long loadoutInteractionTime = 0;
     public static volatile int loadoutInteractionStage = 0;
@@ -27,6 +29,7 @@ public class LoadoutManager {
     public static volatile boolean loadoutGuiDetected = false;
     public static volatile boolean loadoutGuiCloseComplete = true;
     public static volatile long loadoutTimelineStartTime = 0;
+    private static volatile boolean loadoutChatConfirmed = false;
     private static volatile long loadoutRequestId = 0;
 
     public static void resetState() {
@@ -43,6 +46,7 @@ public class LoadoutManager {
         loadoutOpenPendingTime = 0;
         loadoutFirstClickDelayMs = 0;
         loadoutTimelineStartTime = 0;
+        loadoutChatConfirmed = false;
     }
 
     public static void triggerLoadoutSwap(Minecraft client, int slot) {
@@ -91,6 +95,7 @@ public class LoadoutManager {
         loadoutTimelineStartTime = 0;
         loadoutOpenPendingTime = 0;
         loadoutFirstClickDelayMs = 0;
+        loadoutChatConfirmed = false;
         shouldRestartFarmingAfterSwap = true;
         MacroStateManager.setCurrentState(MacroState.State.WARDROBE);
         ClientUtils.sendDebugMessage("Triggering loadout swap to slot " + slot);
@@ -116,6 +121,7 @@ public class LoadoutManager {
         loadoutTimelineStartTime = 0;
         loadoutOpenPendingTime = 0;
         loadoutFirstClickDelayMs = 0;
+        loadoutChatConfirmed = false;
         ClientUtils.sendCommand("/loadout");
     }
 
@@ -133,6 +139,7 @@ public class LoadoutManager {
         loadoutTimelineStartTime = 0;
         loadoutOpenPendingTime = 0;
         loadoutFirstClickDelayMs = 0;
+        loadoutChatConfirmed = false;
 
         if (MacroStateManager.getCurrentState() == MacroState.State.WARDROBE) {
             MacroStateManager.setCurrentState(MacroState.State.FARMING);
@@ -174,7 +181,12 @@ public class LoadoutManager {
         Slot slot = screen.getMenu().slots.get(slotIdx);
 
         if (loadoutInteractionStage == 1) {
-            if (now - loadoutInteractionTime < ClientUtils.getGuiClickDelayMs(false)) {
+            if (!loadoutChatConfirmed && now - loadoutInteractionTime >= LOADOUT_CHAT_RETRY_DELAY_MS) {
+                sendTimedDebug(client, "Retrying loadout slot " + targetLoadoutSlot, now);
+                ClientUtils.performSlotClick(screen, slot.index, 0, ContainerInput.PICKUP);
+                loadoutInteractionTime = now;
+            }
+            if (!loadoutChatConfirmed) {
                 return;
             }
             finishLoadoutAfterClick(client, targetLoadoutSlot);
@@ -190,9 +202,20 @@ public class LoadoutManager {
         }
 
         sendTimedDebug(client, "Clicked loadout slot " + targetLoadoutSlot, now);
+        loadoutChatConfirmed = false;
         ClientUtils.performSlotClick(screen, slot.index, 0, ContainerInput.PICKUP);
         loadoutInteractionTime = now;
         loadoutInteractionStage = 1;
+    }
+
+    public static void onChatMessage(String plainText) {
+        if (!isSwappingLoadout || loadoutInteractionStage != 1 || loadoutChatConfirmed
+                || plainText == null || !plainText.contains("Loadout")) {
+            return;
+        }
+
+        loadoutChatConfirmed = true;
+        ClientUtils.sendDebugMessage("Loadout chat confirmation received.");
     }
 
     private static void finishLoadoutAfterClick(Minecraft client, int clickedLoadoutSlot) {
@@ -205,6 +228,7 @@ public class LoadoutManager {
         isSwappingLoadout = false;
         loadoutGuiDetected = false;
         loadoutInteractionStage = 0;
+        loadoutChatConfirmed = false;
         loadoutOpenPendingTime = 0;
         loadoutFirstClickDelayMs = 0;
 

--- a/src/main/java/dev/aether/modules/pest/PestManager.java
+++ b/src/main/java/dev/aether/modules/pest/PestManager.java
@@ -484,12 +484,13 @@ public class PestManager {
             return false;
         }
 
+        PestTabSnapshot data = parseTabList(client);
         if (spawnedCount > 0) {
-            predictedAliveCount = Math.min(99, predictedAliveCount + spawnedCount);
+            predictedAliveCount = reconcileChatSpawnCount(
+                    predictedAliveCount, spawnedCount, data.aliveCount());
             lastChatSpawnUpdateMs = System.currentTimeMillis();
         }
 
-        PestTabSnapshot data = parseTabList(client);
         syncPredictedAliveFromTab(data.aliveCount());
         int effectiveAlive = getEffectiveAliveCount(data.aliveCount());
 
@@ -603,6 +604,13 @@ public class PestManager {
             int tabAliveCount,
             int effectiveAliveCount) {
         return estimateCompletion ? effectiveAliveCount : Math.max(0, tabAliveCount);
+    }
+
+    static int reconcileChatSpawnCount(int previousPrediction, int spawnedCount, int tabAliveCount) {
+        if (tabAliveCount >= 0) {
+            return tabAliveCount;
+        }
+        return Math.min(99, Math.max(0, previousPrediction) + Math.max(0, spawnedCount));
     }
 
     private static boolean hasRecentLocalKill(long now) {

--- a/src/test/java/dev/aether/modules/pest/PestManagerCompletionTest.java
+++ b/src/test/java/dev/aether/modules/pest/PestManagerCompletionTest.java
@@ -15,4 +15,14 @@ class PestManagerCompletionTest {
         assertEquals(6, PestManager.selectCompletionAliveCount(false, 6, 3));
         assertEquals(0, PestManager.selectCompletionAliveCount(false, -1, 3));
     }
+
+    @Test
+    void chatSpawnDoesNotDoubleCountPestsAlreadyShownInTab() {
+        assertEquals(6, PestManager.reconcileChatSpawnCount(6, 6, 6));
+    }
+
+    @Test
+    void chatSpawnRemainsFallbackWhenTabCountIsUnavailable() {
+        assertEquals(12, PestManager.reconcileChatSpawnCount(6, 6, -1));
+    }
 }


### PR DESCRIPTION
previously it closed regardless of whether swap was successful or not. Now checks for chat message confirmation
also fixed a double counting pest issue