### PR TITLE
add coins/copper limit & only accept rare

### DIFF
--- a/src/main/java/dev/aether/config/AetherConfig.java
+++ b/src/main/java/dev/aether/config/AetherConfig.java
@@ -503,6 +503,10 @@ public final class AetherConfig {
         public static final StringEntry VISITOR_CUSTOM_ITEM = Config.string("visitorCustomItem", "");
         public static final IntEntry VISITOR_MAX_PURCHASE_LIMIT = Config.integer("visitorMaxPurchaseLimit", 10_000_000)
                         .range(0, 20_000_000);
+        public static final BooleanEntry VISITOR_COINS_PER_COPPER = Config.bool("visitorCoinsPerCopper", false);
+        public static final IntEntry VISITOR_COINS_PER_COPPER_LIMIT = Config.integer("visitorCoinsPerCopperLimit", 20_000)
+                        .range(0, 100_000);
+        public static final BooleanEntry VISITOR_ONLY_RARE_DROPS = Config.bool("visitorOnlyRareDrops", false);
         public static final BooleanEntry DISABLE_VISITORS_DURING_JACOBS_CONTEST = Config.bool("disableVisitorsDuringJacobsContest", false);
         public static final BooleanEntry DISABLE_COMPACTORS_DURING_VISITORS = Config.bool("disableCompactorsDuringVisitors", false);
         public static final FloatEntry VISITOR_FOV_RANGE = Config.floatVal("visitorFovRange", 12.0f)

--- a/src/main/java/dev/aether/modules/profit/ProfitManager.java
+++ b/src/main/java/dev/aether/modules/profit/ProfitManager.java
@@ -226,6 +226,10 @@ public final class ProfitManager {
         return PRICING.getItemPrice(itemName);
     }
 
+    public static double getNpcPrice(String itemName) {
+        return PRICING.getNpcPrice(itemName);
+    }
+
     public static double getItemValue(String itemName, long count) {
         return PRICING.getItemValue(itemName, count);
     }

--- a/src/main/java/dev/aether/modules/profit/ProfitPricing.java
+++ b/src/main/java/dev/aether/modules/profit/ProfitPricing.java
@@ -279,6 +279,10 @@ public final class ProfitPricing {
         return getPreferredPrice(resolveLookupKey(cleanName));
     }
 
+    public double getNpcPrice(String itemName) {
+        return TRACKED_ITEMS.getOrDefault(resolveLookupKey(itemName), 0.0);
+    }
+
     public double getItemValue(String itemName, long count) {
         String cleanName = sanitizeName(itemName);
         if (count < 0L) {

--- a/src/main/java/dev/aether/modules/visitor/VisitorsMacro.java
+++ b/src/main/java/dev/aether/modules/visitor/VisitorsMacro.java
@@ -64,6 +64,10 @@ import java.util.regex.Pattern;
 public class VisitorsMacro {
 
     private static final Pattern ITEM_PATTERN = Pattern.compile("^(.+?)\\s+x([\\d,]+)$");
+    private static final Pattern COPPER_PATTERN = Pattern.compile("([\\d,]+)\\s+Copper", Pattern.CASE_INSENSITIVE);
+    private static final Set<String> RARE_REWARDS = Set.of(
+            "Dedication", "Cultivating", "Delicate", "Replenish", "Music Rune",
+            "Green Bandana", "Overgrown Grass", "Space Helmet", "Copper Dye");
     private static final int ACCEPT_OFFER_SLOT = 29;
     private static final int REJECT_OFFER_SLOT = 33;
     private static final long COMPACTOR_GUI_TIMEOUT_MS = 2500L;
@@ -321,9 +325,17 @@ public class VisitorsMacro {
         MacroWorkerThread.sleep(ClientUtils.getGuiClickDelayMs(true));
 
         // Read required items from "Accept Offer" lore
-        List<ItemRequirement> requirements = readRequirements(client);
-        if (requirements == null) {
+        VisitorOffer offer = readOffer(client);
+        if (offer == null) {
             msg(client, "\u00A7cCould not read requirements for: " + visitorName);
+            closeScreen(client);
+            return false;
+        }
+        List<ItemRequirement> requirements = offer.requirements;
+
+        if (!shouldAcceptOffer(offer)) {
+            clickRejectOffer(client);
+            MacroWorkerThread.sleep(300);
             closeScreen(client);
             return false;
         }
@@ -427,6 +439,50 @@ public class VisitorsMacro {
             buyValue = ProfitManager.getItemPrice(req.name) * req.count;
         }
         return (long) Math.ceil(Math.abs(buyValue));
+    }
+
+    private static boolean shouldAcceptOffer(VisitorOffer offer) {
+        boolean coinsPerCopperEnabled = AetherConfig.VISITOR_COINS_PER_COPPER.get();
+        boolean onlyRareDrops = AetherConfig.VISITOR_ONLY_RARE_DROPS.get();
+        if (!coinsPerCopperEnabled && !onlyRareDrops) {
+            return true;
+        }
+
+        if (onlyRareDrops && offer.hasRareReward) {
+            return true;
+        }
+
+        double npcCost = 0.0;
+        for (ItemRequirement requirement : offer.requirements) {
+            double price = ProfitManager.getNpcPrice(requirement.name);
+            if (price <= 0.0) {
+                ClientUtils.sendDebugMessage("[VisitorsMacro] Unknown NPC price: " + requirement.name);
+                return false;
+            }
+            npcCost += price * requirement.count;
+        }
+
+        int coinsPerCopper = calculatePricePerCopper(npcCost, offer.copper);
+        boolean accepted = shouldAcceptOffer(coinsPerCopperEnabled,
+                AetherConfig.VISITOR_COINS_PER_COPPER_LIMIT.get(), onlyRareDrops,
+                offer.hasRareReward, offer.copper, coinsPerCopper);
+        if (!accepted) {
+            ClientUtils.sendDebugMessage("[VisitorsMacro] Rejecting offer: " + coinsPerCopper
+                    + " coins/copper, copper=" + offer.copper + ", rare=" + offer.hasRareReward);
+        }
+        return accepted;
+    }
+
+    static int calculatePricePerCopper(double totalPrice, int copper) {
+        if (copper <= 0) return 0;
+        return (int) (totalPrice / copper);
+    }
+
+    static boolean shouldAcceptOffer(boolean coinsPerCopperEnabled, int limit, boolean onlyRareDrops,
+            boolean hasRareReward, int copper, int coinsPerCopper) {
+        if (onlyRareDrops && hasRareReward) return true;
+        if (coinsPerCopperEnabled) return copper > 0 && coinsPerCopper <= limit;
+        return !onlyRareDrops;
     }
 
     private static String formatCoins(long coins) {
@@ -909,7 +965,7 @@ public class VisitorsMacro {
         return !title.equals(target);
     }
 
-    private static List<ItemRequirement> readRequirements(Minecraft client) {
+    private static VisitorOffer readOffer(Minecraft client) {
         if (!(client.screen instanceof AbstractContainerScreen<?> screen))
             return null;
 
@@ -930,6 +986,9 @@ public class VisitorsMacro {
 
         List<ItemRequirement> requirements = new ArrayList<>();
         boolean parsingRequired = false;
+        boolean parsingRewards = false;
+        int copper = 0;
+        boolean hasRareReward = false;
 
         for (Component line : loreCmp.lines()) {
             String text = stripColors(line.getString()).trim();
@@ -938,11 +997,12 @@ public class VisitorsMacro {
 
             if (text.contains("Required:") || text.contains("Items Required:")) {
                 parsingRequired = true;
+                parsingRewards = false;
                 continue;
             }
-            if (text.contains("Rewards:") || text.contains("Copper") || text.contains("Garden Experience")) {
-                if (parsingRequired)
-                    parsingRequired = false;
+            if (text.contains("Rewards:")) {
+                parsingRequired = false;
+                parsingRewards = true;
                 continue;
             }
 
@@ -961,10 +1021,23 @@ public class VisitorsMacro {
                     requirements.add(new ItemRequirement(text.trim(), 1));
                     ClientUtils.sendDebugMessage("[VisitorsMacro] Required: " + text.trim() + " x1");
                 }
+            } else if (parsingRewards) {
+                copper = Math.max(copper, parseCopperReward(text));
+                hasRareReward |= hasRareReward(text);
             }
         }
 
-        return requirements;
+        return new VisitorOffer(requirements, copper, hasRareReward);
+    }
+
+    static int parseCopperReward(String text) {
+        Matcher matcher = COPPER_PATTERN.matcher(text);
+        return matcher.find() ? Integer.parseInt(matcher.group(1).replace(",", "")) : 0;
+    }
+
+    static boolean hasRareReward(String text) {
+        return RARE_REWARDS.stream().anyMatch(reward -> text.toLowerCase(Locale.ROOT)
+                .contains(reward.toLowerCase(Locale.ROOT)));
     }
 
     private static boolean checkHasItems(Minecraft client) {
@@ -1324,5 +1397,8 @@ public class VisitorsMacro {
             this.name = name;
             this.count = count;
         }
+    }
+
+    private record VisitorOffer(List<ItemRequirement> requirements, int copper, boolean hasRareReward) {
     }
 }

--- a/src/main/java/dev/aether/ui/providers/modules/VisitorRegistryProvider.java
+++ b/src/main/java/dev/aether/ui/providers/modules/VisitorRegistryProvider.java
@@ -41,6 +41,26 @@ public final class VisitorRegistryProvider extends AbstractModulesRegistryProvid
                     AetherConfig.save();
                 })
                 .withDecimals(1).withSuffix("m"));
+        group.add(new ToggleSetting("Max Coins/Copper",
+                () -> AetherConfig.VISITOR_COINS_PER_COPPER.get(),
+                v -> {
+                    AetherConfig.VISITOR_COINS_PER_COPPER.set(v);
+                    AetherConfig.save();
+                }));
+        group.add(new SliderSetting("Coins/Copper Limit", 0.0f, 100.0f,
+                () -> AetherConfig.VISITOR_COINS_PER_COPPER_LIMIT.get() / 1_000.0f,
+                v -> {
+                    AetherConfig.VISITOR_COINS_PER_COPPER_LIMIT.set(Math.round(v * 1_000.0f));
+                    AetherConfig.save();
+                })
+                .withDecimals(1).withSuffix("k")
+                .visibleWhen(() -> AetherConfig.VISITOR_COINS_PER_COPPER.get()));
+        group.add(new ToggleSetting("Only Accept Rare Drops",
+                () -> AetherConfig.VISITOR_ONLY_RARE_DROPS.get(),
+                v -> {
+                    AetherConfig.VISITOR_ONLY_RARE_DROPS.set(v);
+                    AetherConfig.save();
+                }));
         group.add(new ListSetting("Visitor Ignored", "Add visitor name",
                 () -> AetherConfig.VISITOR_ignore.get(),
                 v -> {

--- a/src/test/java/dev/aether/modules/visitor/VisitorsMacroTest.java
+++ b/src/test/java/dev/aether/modules/visitor/VisitorsMacroTest.java
@@ -1,0 +1,22 @@
+package dev.aether.modules.visitor;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class VisitorsMacroTest {
+    @Test
+    void appliesCoinsPerCopperAndRareDropRules() {
+        assertEquals(20_000, VisitorsMacro.calculatePricePerCopper(260_000, 13));
+        assertEquals(0, VisitorsMacro.calculatePricePerCopper(260_000, 0));
+        assertEquals(13, VisitorsMacro.parseCopperReward("+13 Copper (Saying 14k per)"));
+        assertTrue(VisitorsMacro.hasRareReward("+1 Overgrown Grass"));
+
+        assertTrue(VisitorsMacro.shouldAcceptOffer(true, 20_000, true, false, 13, 20_000));
+        assertFalse(VisitorsMacro.shouldAcceptOffer(true, 20_000, true, false, 13, 20_001));
+        assertTrue(VisitorsMacro.shouldAcceptOffer(true, 20_000, true, true, 13, 20_001));
+        assertFalse(VisitorsMacro.shouldAcceptOffer(false, 20_000, true, false, 13, 1));
+    }
+}


### PR DESCRIPTION
coins/copper limit will ignore limit if an npc has a rare item (no toggle currently since i dont think anyone would want to reject a visitor with grass or dedi 4 for example just because it cost 15k coins/copper)

coins/copper based on visitor crops npc price
rare drops list based on the one from farmhelper idk if they added anything new that should be acceptedc