### PR TITLE
qol-add

### DIFF
--- a/src/main/java/dev/aether/config/AetherConfig.java
+++ b/src/main/java/dev/aether/config/AetherConfig.java
@@ -473,6 +473,7 @@ public final class AetherConfig {
         // -- MANUAL PEST MODE ------------------------------------------------------
 
         public static final BooleanEntry MANUAL_PEST_MODE = Config.bool("manualPestMode", false);
+        public static final BooleanEntry VACCUM_WHEN_START = Config.bool("vaccumwhenstart", false);
         public static final StringEntry MANUAL_PEST_SOUND_FILE = Config.string("manualPestSoundFile", "fnaf.mp3");
 
         // -- PEST EXCHANGE ---------------------------------------------------------
@@ -864,9 +865,9 @@ public final class AetherConfig {
         public static final StringEntry BEDROCK_PLOT_MAKER_PLOT = Config.string("bedrockPlotMakerPlot", "1");
         /** Post lane-switch delay in milliseconds before evaluating row-end checks again. */
         public static final IntEntry MACRO_LANE_SWITCH_DELAY_MIN = Config.integer("macroLaneSwitchDelayMin", 0)
-                        .range(0, 1000);
+                        .range(0, 5000);
         public static final IntEntry MACRO_LANE_SWITCH_DELAY_MAX = Config.integer("macroLaneSwitchDelayMax", 500)
-                        .range(0, 1000);
+                        .range(0, 5000);
         public static final BooleanEntry FAILSAFE_INVENTORY_SLOT_CHANGED = Config.bool("failsafeInventorySlotChanged", true);
         public static final BooleanEntry FAILSAFE_UNEXPECTED_INVENTORY_GUI = Config.bool("failsafeUnexpectedInventoryGui", true);
         public static final BooleanEntry FAILSAFE_BPS = Config.bool("failsafeBps", true);

--- a/src/main/java/dev/aether/modules/pest/ManualPestManager.java
+++ b/src/main/java/dev/aether/modules/pest/ManualPestManager.java
@@ -135,6 +135,7 @@ public final class ManualPestManager {
         waitingStartedAt = 0L;
         clearedPestTabTicks = 0;
         ClientUtils.sendMessage("\u00A7aManual Pest Mode: pests cleared. Running pest post-actions.", false);
+        UngrabMouse.ungrabMouse();
         PestManager.handlePestCleaningFinished(client);
     }
 

--- a/src/main/java/dev/aether/modules/pest/helpers/PestLifecycleManager.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestLifecycleManager.java
@@ -6,6 +6,7 @@ import dev.aether.macro.MacroStateManager;
 import dev.aether.macro.MacroWorkerThread;
 import dev.aether.macro.farming.FarmingMacroManager;
 import dev.aether.modules.gear.helpers.LoadoutManager;
+import dev.aether.modules.failsafe.FailsafeManager;
 import dev.aether.modules.pest.ManualPestManager;
 import dev.aether.modules.pest.PestManager;
 import dev.aether.util.ClientUtils;
@@ -196,6 +197,7 @@ public final class PestLifecycleManager {
                 + (manualMode ? "manual" : "automatic") + ").");
 
         if (manualMode) {
+            switchToVacuumForManualStart(client);
             if (!ManualPestManager.startCleaningStage(client, pestCount)) {
                 PestManager.handlePestCleaningFinished(client);
             }
@@ -208,6 +210,22 @@ public final class PestLifecycleManager {
             PestBonusManager.beginReactivation();
         }
         client.execute(() -> PestDestroyer.start(client, plot));
+    }
+
+    private static void switchToVacuumForManualStart(Minecraft client) {
+        if (!AetherConfig.VACCUM_WHEN_START.get()) {
+            return;
+        }
+
+        int vacuumSlot = PestLoadoutHelper.findVacuumHotbarSlot(client);
+        if (vacuumSlot < 0) {
+            ClientUtils.sendMessage("\u00A7cManual Pest Mode: no vacuum found in hotbar.", false);
+            ClientUtils.sendDebugMessage("Manual Pest Mode: Switch to Vacuum When Start enabled, but no vacuum was found.");
+            return;
+        }
+
+        FailsafeManager.selectHotbarSlot(client, vacuumSlot);
+        ClientUtils.sendDebugMessage("Manual Pest Mode: switched to vacuum slot " + (vacuumSlot + 1) + ".");
     }
 
     static boolean shouldSkipCleaningAfterBallsack(

--- a/src/main/java/dev/aether/ui/providers/modules/FarmingSettingsFactory.java
+++ b/src/main/java/dev/aether/ui/providers/modules/FarmingSettingsFactory.java
@@ -32,7 +32,7 @@ final class FarmingSettingsFactory {
     }
 
     static RangeSliderSetting laneSwitchDelaySetting() {
-        return intDelayRangeSetting("Lane Switch Delay", 0f, 1000f,
+        return intDelayRangeSetting("Lane Switch Delay", 0f, 5000f,
                 () -> AetherConfig.MACRO_LANE_SWITCH_DELAY_MIN.get(),
                 () -> AetherConfig.MACRO_LANE_SWITCH_DELAY_MAX.get(),
                 (min, max) -> {

--- a/src/main/java/dev/aether/ui/providers/modules/PestManagerRegistryProvider.java
+++ b/src/main/java/dev/aether/ui/providers/modules/PestManagerRegistryProvider.java
@@ -239,6 +239,13 @@ public final class PestManagerRegistryProvider extends AbstractModulesRegistryPr
                             AetherConfig.MANUAL_PEST_MODE.set(v);
                             AetherConfig.save();
                         })
+                .add(new ToggleSetting("Switch to Vacuum When Start",
+                        () -> AetherConfig.VACCUM_WHEN_START.get(),
+                        v -> {
+                            AetherConfig.VACCUM_WHEN_START.set(v);
+                            AetherConfig.save();
+                        })
+                        .visibleWhen(() -> AetherConfig.MANUAL_PEST_MODE.get()))
                 .add(new DropdownSetting("Manual Pest Sound", manualPestSoundOptions,
                         () -> getSoundIndex(manualPestSoundOptions, AetherConfig.MANUAL_PEST_SOUND_FILE.get()),
                         i -> {


### PR DESCRIPTION
add : switch to vaccum at start mannual pest farm
add : Increase the lane switch delay up to 5 seconds
add : Ungrabmouse immediately after clicking the Early Request Manual button to prevent mouse movement from causing unintended pitch/yaw changes