### PR TITLE
Add qol

### DIFF
--- a/src/main/java/dev/aether/config/AetherConfig.java
+++ b/src/main/java/dev/aether/config/AetherConfig.java
@@ -473,6 +473,7 @@ public final class AetherConfig {
         // -- MANUAL PEST MODE ------------------------------------------------------
 
         public static final BooleanEntry MANUAL_PEST_MODE = Config.bool("manualPestMode", false);
+        public static final BooleanEntry VACCUM_WHEN_START = Config.bool("vaccumwhenstart", false);
         public static final StringEntry MANUAL_PEST_SOUND_FILE = Config.string("manualPestSoundFile", "fnaf.mp3");
 
         // -- PEST EXCHANGE ---------------------------------------------------------
@@ -864,9 +865,9 @@ public final class AetherConfig {
         public static final StringEntry BEDROCK_PLOT_MAKER_PLOT = Config.string("bedrockPlotMakerPlot", "1");
         /** Post lane-switch delay in milliseconds before evaluating row-end checks again. */
         public static final IntEntry MACRO_LANE_SWITCH_DELAY_MIN = Config.integer("macroLaneSwitchDelayMin", 0)
-                        .range(0, 1000);
+                        .range(0, 5000);
         public static final IntEntry MACRO_LANE_SWITCH_DELAY_MAX = Config.integer("macroLaneSwitchDelayMax", 500)
-                        .range(0, 1000);
+                        .range(0, 5000);
         public static final BooleanEntry FAILSAFE_INVENTORY_SLOT_CHANGED = Config.bool("failsafeInventorySlotChanged", true);
         public static final BooleanEntry FAILSAFE_UNEXPECTED_INVENTORY_GUI = Config.bool("failsafeUnexpectedInventoryGui", true);
         public static final BooleanEntry FAILSAFE_BPS = Config.bool("failsafeBps", true);

--- a/src/main/java/dev/aether/config/AetherConfig.java
+++ b/src/main/java/dev/aether/config/AetherConfig.java
@@ -862,6 +862,10 @@ public final class AetherConfig {
                         .range(-240, 240);
         public static final ListEntry<String> MACRO_FARM_WAYPOINTS = Config.list("macroFarmWaypoints",
                         Collections.emptyList(), String.class);
+        /** Horizontal distance in blocks used to trigger a Custom Farm waypoint switch. */
+        public static final FloatEntry MACRO_CUSTOM_WAYPOINT_SWITCH_RADIUS = Config
+                        .floatVal("macroCustomWaypointSwitchRadius", 0.20f)
+                        .range(0.05f, 1.00f);
         public static final StringEntry BEDROCK_PLOT_MAKER_PLOT = Config.string("bedrockPlotMakerPlot", "1");
         /** Post lane-switch delay in milliseconds before evaluating row-end checks again. */
         public static final IntEntry MACRO_LANE_SWITCH_DELAY_MIN = Config.integer("macroLaneSwitchDelayMin", 0)

--- a/src/main/java/dev/aether/config/FarmingMacroPresetManager.java
+++ b/src/main/java/dev/aether/config/FarmingMacroPresetManager.java
@@ -203,6 +203,7 @@ public final class FarmingMacroPresetManager {
         addEntry(entries, AetherConfig.MACRO_FAST_LANE_LEFT_BOUNDARY);
         addEntry(entries, AetherConfig.MACRO_FAST_LANE_RIGHT_BOUNDARY);
         addEntry(entries, AetherConfig.MACRO_FARM_WAYPOINTS);
+        addEntry(entries, AetherConfig.MACRO_CUSTOM_WAYPOINT_SWITCH_RADIUS);
         addEntry(entries, AetherConfig.SQUEAKY_MOUSEMAT);
         addEntry(entries, AetherConfig.MACRO_USE_CUSTOM_PITCH);
         addEntry(entries, AetherConfig.MACRO_CUSTOM_PITCH);

--- a/src/main/java/dev/aether/macro/farming/CustomFarmMacro.java
+++ b/src/main/java/dev/aether/macro/farming/CustomFarmMacro.java
@@ -12,13 +12,6 @@ public class CustomFarmMacro extends AbstractFarmingMacro {
     private static final double REACHED_VERTICAL_DISTANCE = 1.5;
 
     private int activeWaypointIndex = 0;
-
-    /**
-     * Custom waypoint switches are confirmed first, then committed after the
-     * configured lane-switch delay. While confirmation is pending,
-     * activeWaypointIndex intentionally remains unchanged so invokeState()
-     * continues holding the current farm key and attack.
-     */
     private boolean keySwitchConfirm = false;
     private int pendingWaypointIndex = -1;
     private int keySwitchDelayTicks = 0;
@@ -65,8 +58,6 @@ public class CustomFarmMacro extends AbstractFarmingMacro {
             resetKeySwitchConfirmation();
         }
 
-        // A waypoint switch has already been confirmed. Keep the current
-        // active waypoint/key while the randomized lane-switch delay counts down.
         if (keySwitchConfirm) {
             if (pendingWaypointIndex < 0 || pendingWaypointIndex >= waypoints.size()) {
                 resetKeySwitchConfirmation();
@@ -80,8 +71,6 @@ public class CustomFarmMacro extends AbstractFarmingMacro {
                     return;
                 }
 
-                // Delay finished: now commit the new waypoint/key, then reset
-                // keySwitchConfirm so the next waypoint can be detected.
                 commitPendingWaypoint();
                 changeState(displayStateFor(waypoints.get(activeWaypointIndex)));
                 return;
@@ -93,16 +82,11 @@ public class CustomFarmMacro extends AbstractFarmingMacro {
                 continue;
             }
 
-            // Preserve the original first-match behaviour. If the player is
-            // still inside the active waypoint's radius, do not scan through
-            // it and accidentally confirm an overlapping waypoint.
             if (i == activeWaypointIndex) {
                 break;
             }
 
             beginKeySwitchConfirmation(i);
-
-            // A zero randomized delay should behave as an immediate switch.
             if (keySwitchDelayTicks <= 0) {
                 commitPendingWaypoint();
             }
@@ -139,8 +123,6 @@ public class CustomFarmMacro extends AbstractFarmingMacro {
                 AetherConfig.MACRO_LANE_SWITCH_DELAY_MIN.get(),
                 AetherConfig.MACRO_LANE_SWITCH_DELAY_MAX.get());
 
-        // Pick a fresh random delay inside the configured min/max range for
-        // every confirmed waypoint switch, matching AbstractFarmingMacro.
         keySwitchDelayTicks = (delayMs + 25) / 50;
     }
 

--- a/src/main/java/dev/aether/macro/farming/CustomFarmMacro.java
+++ b/src/main/java/dev/aether/macro/farming/CustomFarmMacro.java
@@ -2,16 +2,26 @@ package dev.aether.macro.farming;
 
 import dev.aether.config.AetherConfig;
 import dev.aether.config.FarmWaypoint;
+import dev.aether.config.ConfigHelpers;
 import dev.aether.config.FarmWaypoints;
 import net.minecraft.client.Minecraft;
 
 import java.util.List;
 
 public class CustomFarmMacro extends AbstractFarmingMacro {
-    private static final double REACHED_HORIZONTAL_DISTANCE_SQ = 0.2 * 0.2;
     private static final double REACHED_VERTICAL_DISTANCE = 1.5;
 
     private int activeWaypointIndex = 0;
+
+    /**
+     * Custom waypoint switches are confirmed first, then committed after the
+     * configured lane-switch delay. While confirmation is pending,
+     * activeWaypointIndex intentionally remains unchanged so invokeState()
+     * continues holding the current farm key and attack.
+     */
+    private boolean keySwitchConfirm = false;
+    private int pendingWaypointIndex = -1;
+    private int keySwitchDelayTicks = 0;
 
     @Override
     public void onEnable(Minecraft mc) {
@@ -22,6 +32,13 @@ public class CustomFarmMacro extends AbstractFarmingMacro {
         }
         List<FarmWaypoint> waypoints = FarmWaypoints.get();
         activeWaypointIndex = initialActiveIndex(mc, waypoints);
+        resetKeySwitchConfirmation();
+    }
+
+    @Override
+    public void onDisable(Minecraft mc) {
+        resetKeySwitchConfirmation();
+        super.onDisable(mc);
     }
 
     @Override
@@ -39,19 +56,57 @@ public class CustomFarmMacro extends AbstractFarmingMacro {
         if (waypoints.isEmpty()) {
             changeState(State.NONE);
             activeWaypointIndex = 0;
+            resetKeySwitchConfirmation();
             return;
         }
 
         if (activeWaypointIndex < 0 || activeWaypointIndex >= waypoints.size()) {
             activeWaypointIndex = 0;
+            resetKeySwitchConfirmation();
+        }
+
+        // A waypoint switch has already been confirmed. Keep the current
+        // active waypoint/key while the randomized lane-switch delay counts down.
+        if (keySwitchConfirm) {
+            if (pendingWaypointIndex < 0 || pendingWaypointIndex >= waypoints.size()) {
+                resetKeySwitchConfirmation();
+            } else {
+                if (keySwitchDelayTicks > 0) {
+                    keySwitchDelayTicks--;
+                }
+
+                if (keySwitchDelayTicks > 0) {
+                    changeState(displayStateFor(waypoints.get(activeWaypointIndex)));
+                    return;
+                }
+
+                // Delay finished: now commit the new waypoint/key, then reset
+                // keySwitchConfirm so the next waypoint can be detected.
+                commitPendingWaypoint();
+                changeState(displayStateFor(waypoints.get(activeWaypointIndex)));
+                return;
+            }
         }
 
         for (int i = 0; i < waypoints.size(); i++) {
-            if (isAtWaypoint(mc, waypoints.get(i))) {
-                activeWaypointIndex = i;
-                FarmWaypoints.saveLastWaypoint(i);
+            if (!isAtWaypoint(mc, waypoints.get(i))) {
+                continue;
+            }
+
+            // Preserve the original first-match behaviour. If the player is
+            // still inside the active waypoint's radius, do not scan through
+            // it and accidentally confirm an overlapping waypoint.
+            if (i == activeWaypointIndex) {
                 break;
             }
+
+            beginKeySwitchConfirmation(i);
+
+            // A zero randomized delay should behave as an immediate switch.
+            if (keySwitchDelayTicks <= 0) {
+                commitPendingWaypoint();
+            }
+            break;
         }
 
         changeState(displayStateFor(waypoints.get(activeWaypointIndex)));
@@ -74,6 +129,31 @@ public class CustomFarmMacro extends AbstractFarmingMacro {
                 true,
                 false,
                 false);
+    }
+
+    private void beginKeySwitchConfirmation(int waypointIndex) {
+        keySwitchConfirm = true;
+        pendingWaypointIndex = waypointIndex;
+
+        int delayMs = ConfigHelpers.getRandomizedDelay(
+                AetherConfig.MACRO_LANE_SWITCH_DELAY_MIN.get(),
+                AetherConfig.MACRO_LANE_SWITCH_DELAY_MAX.get());
+
+        // Pick a fresh random delay inside the configured min/max range for
+        // every confirmed waypoint switch, matching AbstractFarmingMacro.
+        keySwitchDelayTicks = (delayMs + 25) / 50;
+    }
+
+    private void commitPendingWaypoint() {
+        activeWaypointIndex = pendingWaypointIndex;
+        FarmWaypoints.saveLastWaypoint(activeWaypointIndex);
+        resetKeySwitchConfirmation();
+    }
+
+    private void resetKeySwitchConfirmation() {
+        keySwitchConfirm = false;
+        pendingWaypointIndex = -1;
+        keySwitchDelayTicks = 0;
     }
 
     private int initialActiveIndex(Minecraft mc, List<FarmWaypoint> waypoints) {
@@ -101,7 +181,9 @@ public class CustomFarmMacro extends AbstractFarmingMacro {
         double dx = mc.player.getX() - waypoint.x();
         double dz = mc.player.getZ() - waypoint.z();
         double dy = Math.abs(mc.player.getY() - waypoint.y());
-        return dx * dx + dz * dz <= REACHED_HORIZONTAL_DISTANCE_SQ
+        double radius = AetherConfig.MACRO_CUSTOM_WAYPOINT_SWITCH_RADIUS.get();
+        double radiusSq = radius * radius;
+        return dx * dx + dz * dz <= radiusSq
                 && dy <= REACHED_VERTICAL_DISTANCE;
     }
 

--- a/src/main/java/dev/aether/modules/pest/ManualPestManager.java
+++ b/src/main/java/dev/aether/modules/pest/ManualPestManager.java
@@ -135,6 +135,7 @@ public final class ManualPestManager {
         waitingStartedAt = 0L;
         clearedPestTabTicks = 0;
         ClientUtils.sendMessage("\u00A7aManual Pest Mode: pests cleared. Running pest post-actions.", false);
+        UngrabMouse.ungrabMouse();
         PestManager.handlePestCleaningFinished(client);
     }
 

--- a/src/main/java/dev/aether/modules/pest/helpers/PestLifecycleManager.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestLifecycleManager.java
@@ -6,6 +6,7 @@ import dev.aether.macro.MacroStateManager;
 import dev.aether.macro.MacroWorkerThread;
 import dev.aether.macro.farming.FarmingMacroManager;
 import dev.aether.modules.gear.helpers.LoadoutManager;
+import dev.aether.modules.failsafe.FailsafeManager;
 import dev.aether.modules.pest.ManualPestManager;
 import dev.aether.modules.pest.PestManager;
 import dev.aether.util.ClientUtils;
@@ -196,6 +197,7 @@ public final class PestLifecycleManager {
                 + (manualMode ? "manual" : "automatic") + ").");
 
         if (manualMode) {
+            switchToVacuumForManualStart(client);
             if (!ManualPestManager.startCleaningStage(client, pestCount)) {
                 PestManager.handlePestCleaningFinished(client);
             }
@@ -208,6 +210,22 @@ public final class PestLifecycleManager {
             PestBonusManager.beginReactivation();
         }
         client.execute(() -> PestDestroyer.start(client, plot));
+    }
+
+    private static void switchToVacuumForManualStart(Minecraft client) {
+        if (!AetherConfig.VACCUM_WHEN_START.get()) {
+            return;
+        }
+
+        int vacuumSlot = PestLoadoutHelper.findVacuumHotbarSlot(client);
+        if (vacuumSlot < 0) {
+            ClientUtils.sendMessage("\u00A7cManual Pest Mode: no vacuum found in hotbar.", false);
+            ClientUtils.sendDebugMessage("Manual Pest Mode: Switch to Vacuum When Start enabled, but no vacuum was found.");
+            return;
+        }
+
+        FailsafeManager.selectHotbarSlot(client, vacuumSlot);
+        ClientUtils.sendDebugMessage("Manual Pest Mode: switched to vacuum slot " + (vacuumSlot + 1) + ".");
     }
 
     static boolean shouldSkipCleaningAfterBallsack(

--- a/src/main/java/dev/aether/ui/providers/modules/FarmingMacroRegistryProvider.java
+++ b/src/main/java/dev/aether/ui/providers/modules/FarmingMacroRegistryProvider.java
@@ -196,6 +196,15 @@ public final class FarmingMacroRegistryProvider extends AbstractModulesRegistryP
                 "Farm Waypoints",
                 "Configure custom farm waypoint positions and movement keys");
 
+        group.add(new SliderSetting("Switch Point Radius", 0.05f, 1.00f,
+                () -> AetherConfig.MACRO_CUSTOM_WAYPOINT_SWITCH_RADIUS.get(),
+                v -> {
+                    AetherConfig.MACRO_CUSTOM_WAYPOINT_SWITCH_RADIUS.set(v);
+                    AetherConfig.save();
+                })
+                .withDecimals(2)
+                .withSuffix(" blocks"));
+
         int count = Math.max(1, FarmWaypoints.get().size());
         for (int i = 0; i < count; i++) {
             final int index = i;

--- a/src/main/java/dev/aether/ui/providers/modules/FarmingSettingsFactory.java
+++ b/src/main/java/dev/aether/ui/providers/modules/FarmingSettingsFactory.java
@@ -32,7 +32,7 @@ final class FarmingSettingsFactory {
     }
 
     static RangeSliderSetting laneSwitchDelaySetting() {
-        return intDelayRangeSetting("Lane Switch Delay", 0f, 1000f,
+        return intDelayRangeSetting("Lane Switch Delay", 0f, 5000f,
                 () -> AetherConfig.MACRO_LANE_SWITCH_DELAY_MIN.get(),
                 () -> AetherConfig.MACRO_LANE_SWITCH_DELAY_MAX.get(),
                 (min, max) -> {

--- a/src/main/java/dev/aether/ui/providers/modules/PestManagerRegistryProvider.java
+++ b/src/main/java/dev/aether/ui/providers/modules/PestManagerRegistryProvider.java
@@ -239,6 +239,13 @@ public final class PestManagerRegistryProvider extends AbstractModulesRegistryPr
                             AetherConfig.MANUAL_PEST_MODE.set(v);
                             AetherConfig.save();
                         })
+                .add(new ToggleSetting("Switch to Vacuum When Start",
+                        () -> AetherConfig.VACCUM_WHEN_START.get(),
+                        v -> {
+                            AetherConfig.VACCUM_WHEN_START.set(v);
+                            AetherConfig.save();
+                        })
+                        .visibleWhen(() -> AetherConfig.MANUAL_PEST_MODE.get()))
                 .add(new DropdownSetting("Manual Pest Sound", manualPestSoundOptions,
                         () -> getSoundIndex(manualPestSoundOptions, AetherConfig.MANUAL_PEST_SOUND_FILE.get()),
                         i -> {


### PR DESCRIPTION
feat: switch to vaccum at start mannual pest farm
feat: Increase the lane switch delay up to 5 seconds
feat: Ungrabmouse immediately after clicking the Early Request Manual button to prevent mouse movement from causing unintended pitch/yaw changes
feat: apply Lane Switch Delay to the Custom farm type
feat: add a configurable waypoint detection radius to prevent missed switches when using the Custom farm type