### PR TITLE
fix: use current coflnet search endpoint for bazaar price lookups

### DIFF
--- a/src/main/java/dev/aether/modules/profit/ProfitPricing.java
+++ b/src/main/java/dev/aether/modules/profit/ProfitPricing.java
@@ -430,19 +430,22 @@ public final class ProfitPricing {
         }
 
         try {
-            String encoded = URLEncoder.encode(name, StandardCharsets.UTF_8);
+            // cofl wants %20 for spaces; URLEncoder's + form returns an empty result set
+            String encoded = URLEncoder.encode(name, StandardCharsets.UTF_8).replace("+", "%20");
             HttpClient http = HttpClient.newBuilder()
                     .connectTimeout(Duration.ofSeconds(3))
                     .build();
+            // old /api/items/search 404s since the cofl api change; prices then silently
+            // fell back to npc values, inflating displayed profit vs real instasell
             HttpRequest request = HttpRequest.newBuilder()
-                    .uri(URI.create("https://sky.coflnet.com/api/items/search/" + encoded + "?limit=1"))
+                    .uri(URI.create("https://sky.coflnet.com/api/item/search/" + encoded))
                     .GET()
                     .build();
             HttpResponse<String> response = http.send(request, HttpResponse.BodyHandlers.ofString());
             if (response.statusCode() == 200) {
                 JsonArray results = JsonParser.parseString(response.body()).getAsJsonArray();
                 if (!results.isEmpty()) {
-                    String tag = results.get(0).getAsJsonObject().get("tag").getAsString();
+                    String tag = results.get(0).getAsJsonObject().get("id").getAsString();
                     idByNameCache.put(name, tag);
                     return tag;
                 }

--- a/src/main/java/dev/aether/modules/profit/ProfitPricing.java
+++ b/src/main/java/dev/aether/modules/profit/ProfitPricing.java
@@ -435,8 +435,6 @@ public final class ProfitPricing {
             HttpClient http = HttpClient.newBuilder()
                     .connectTimeout(Duration.ofSeconds(3))
                     .build();
-            // old /api/items/search 404s since the cofl api change; prices then silently
-            // fell back to npc values, inflating displayed profit vs real instasell
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create("https://sky.coflnet.com/api/item/search/" + encoded))
                     .GET()


### PR DESCRIPTION
Profit HUD was showing inflated totals vs real instasell (e.g. ~150m shown vs ~80m actual on mushrooms). Turned out Coflnet retired `/api/items/search/` - it now 404s for every item, so all search-backed bazaar prices silently failed and the tracker fell back to the hardcoded NPC prices (10 coins per mushroom vs ~6.0 red / ~4.6 brown instasell, roughly 1.9x inflation).

Changes in `fetchIdByName`:
- use the current `/api/item/search/{name}` endpoint
- read the `id` field (was `tag`)
- encode spaces as `%20` - the `+` form URLEncoder produces returns an empty result set with HTTP 200

Verified against the live API that the top search hit resolves to the correct item for the tracked crop names.