### PR TITLE
feat(pest): add auto teleport to plot option for manual pest mode

### DIFF
--- a/src/main/java/dev/aether/config/AetherConfig.java
+++ b/src/main/java/dev/aether/config/AetherConfig.java
@@ -474,7 +474,9 @@ public final class AetherConfig {
 
         public static final BooleanEntry MANUAL_PEST_MODE = Config.bool("manualPestMode", false);
         public static final BooleanEntry VACCUM_WHEN_START = Config.bool("vaccumwhenstart", false);
+        public static final BooleanEntry TELEPORT_TO_PLOT_WHEN_START = Config.bool("teleportToPlotWhenStart", false);
         public static final StringEntry MANUAL_PEST_SOUND_FILE = Config.string("manualPestSoundFile", "fnaf.mp3");
+
 
         // -- PEST EXCHANGE ---------------------------------------------------------
 

--- a/src/main/java/dev/aether/modules/pest/helpers/PestLifecycleManager.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestLifecycleManager.java
@@ -197,6 +197,7 @@ public final class PestLifecycleManager {
                 + (manualMode ? "manual" : "automatic") + ").");
 
         if (manualMode) {
+            teleportToPlotForManualStart(client, plot);
             switchToVacuumForManualStart(client);
             if (!ManualPestManager.startCleaningStage(client, pestCount)) {
                 PestManager.handlePestCleaningFinished(client);
@@ -210,6 +211,18 @@ public final class PestLifecycleManager {
             PestBonusManager.beginReactivation();
         }
         client.execute(() -> PestDestroyer.start(client, plot));
+    }
+
+    private static void teleportToPlotForManualStart(Minecraft client, String plot) {
+        if (!AetherConfig.TELEPORT_TO_PLOT_WHEN_START.get()) {
+            return;
+        }
+        if (!PestPlotId.isUsable(plot)) {
+            return;
+        }
+
+        CommandUtils.initiatePlotTp(plot);
+        ClientUtils.sendDebugMessage("Manual Pest Mode: initiated plot tp to plot " + plot + ".");
     }
 
     private static void switchToVacuumForManualStart(Minecraft client) {

--- a/src/main/java/dev/aether/modules/pest/helpers/PestPreStage.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestPreStage.java
@@ -74,6 +74,7 @@ final class PestPreStage {
 
         boolean forcePlotTp =
                 alreadyOnPlot && (AetherConfig.PEST_PLOT_TP_FOR_CURRENT_PLOT.get()
+                        || (AetherConfig.TELEPORT_TO_PLOT_WHEN_START.get() && AetherConfig.MANUAL_PEST_MODE.get())
                         || PestManager.isBallsackShredderActiveForCurrentCycle());
 
         if (alreadyOnPlot && !forcePlotTp) {

--- a/src/main/java/dev/aether/ui/providers/modules/PestManagerRegistryProvider.java
+++ b/src/main/java/dev/aether/ui/providers/modules/PestManagerRegistryProvider.java
@@ -246,6 +246,13 @@ public final class PestManagerRegistryProvider extends AbstractModulesRegistryPr
                             AetherConfig.save();
                         })
                         .visibleWhen(() -> AetherConfig.MANUAL_PEST_MODE.get()))
+                .add(new ToggleSetting("Teleport to Plot When Start",
+                        () -> AetherConfig.TELEPORT_TO_PLOT_WHEN_START.get(),
+                        v -> {
+                            AetherConfig.TELEPORT_TO_PLOT_WHEN_START.set(v);
+                            AetherConfig.save();
+                        })
+                        .visibleWhen(() -> AetherConfig.MANUAL_PEST_MODE.get()))
                 .add(new DropdownSetting("Manual Pest Sound", manualPestSoundOptions,
                         () -> getSoundIndex(manualPestSoundOptions, AetherConfig.MANUAL_PEST_SOUND_FILE.get()),
                         i -> {


### PR DESCRIPTION

Adds a new toggle setting `teleportToPlotWhenStart` ("Teleport to Plot When Start") to **Manual Pest Mode**.

## Changes
- **Config**: Registered `TELEPORT_TO_PLOT_WHEN_START` boolean entry in `AetherConfig.java`.
- **Lifecycle Logic**: Initiates `/plottp <plot>` when starting manual pest cleaning stage in `PestLifecycleManager.java`.
- **Pre-Stage**: Updated `forcePlotTp` condition in `PestPreStage.java` to ensure teleport happens even if already standing on the infested plot.
- **GUI**: Added the `"Teleport to Plot When Start"` toggle setting to the **Manual Pest Killing** group in `PestManagerRegistryProvider.java`.
