### PR TITLE
fix: pest destroyer re-teleports off the roof after PRE stage

### DIFF
--- a/src/main/java/dev/aether/modules/pest/helpers/PestDestroyer.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestDestroyer.java
@@ -99,6 +99,11 @@ public class PestDestroyer {
         if (PestPlotId.isUsable(initialPlot)) {
             runtime.navigation.plotQueue.add(initialPlot);
             runtime.navigation.lastTargetPlot = initialPlot;
+            // The PRE stage has just run /plottp here and climbed onto the roof. Asking the
+            // (lagging) sidebar would send us back down to the plot spawn and strand us in a loop.
+            if (CommandUtils.isFreshKnownPlotChat(initialPlot)) {
+                runtime.navigation.trustPlot(initialPlot, System.currentTimeMillis());
+            }
         }
 
         if (infested != null && !infested.isEmpty()) {
@@ -123,9 +128,11 @@ public class PestDestroyer {
         if (!runtime.navigation.plotQueue.isEmpty()) {
             String currentPlot = getEffectivePlot(client);
             String firstPlot = runtime.navigation.plotQueue.get(0);
+            // A fresh chat confirmation means the PRE stage already did the forced /plottp;
+            // doing it again here would drop us off the roof it just climbed.
             boolean forceCurrentPlotTeleport = plotsEqual(firstPlot, currentPlot)
                             && AetherConfig.PEST_PLOT_TP_FOR_CURRENT_PLOT.get()
-                            && !CommandUtils.isFreshKnownPlotChat(firstPlot, 3000L);
+                            && !CommandUtils.isFreshKnownPlotChat(firstPlot);
             if (forceCurrentPlotTeleport) {
                 runtime.state = State.TELEPORT_TO_PLOT;
                 return;

--- a/src/main/java/dev/aether/modules/pest/helpers/PestNavigationCoordinator.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestNavigationCoordinator.java
@@ -270,8 +270,7 @@ final class PestNavigationCoordinator {
             Context context,
             String plot
     ) {
-        navigationState.trustedPlot = plot;
-        navigationState.trustedPlotExpiresAt = System.currentTimeMillis() + 120_000;
+        navigationState.trustPlot(plot, System.currentTimeMillis());
         navigationState.plotTpSent = false;
         navigationState.plotTpWindow = null;
         if (PestManager.isBallsackShredderActiveForCurrentCycle()) {

--- a/src/main/java/dev/aether/modules/pest/helpers/PestNavigationState.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestNavigationState.java
@@ -10,6 +10,8 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 final class PestNavigationState {
+    private static final long TRUSTED_PLOT_TTL_MS = 120_000L;
+
     Vec3 fireworkFirstPos = null;
     Vec3 fireworkLastPos = null;
     int fireworkParticleCount = 0;
@@ -30,6 +32,13 @@ final class PestNavigationState {
     String lastTargetPlot = null;
     String trustedPlot = null;
     long trustedPlotExpiresAt = 0;
+
+    // The sidebar lags a couple of seconds behind a plot teleport, so a confirmed arrival
+    // is trusted over it for a while to avoid re-teleporting to a plot we're already on.
+    void trustPlot(String plot, long now) {
+        trustedPlot = plot;
+        trustedPlotExpiresAt = now + TRUSTED_PLOT_TTL_MS;
+    }
 
     void resetForRun() {
         fireworkFirstPos = null;


### PR DESCRIPTION
## Problem

After the pest PRE stage runs `/plottp` and etherwarps onto the roof, the CLEANING stage immediately teleported to the same plot again. The sidebar plot line lags a couple of seconds behind the "Teleported you to Plot" chat message, so `getEffectivePlot` still returned the old plot, the destroyer thought it was in the wrong place and re-teleported. That drops the player back to the plot spawn under the roof it just climbed, and from there it looped between plots every 2s until the 30s no-progress abort kicked in with all pests still alive.

## Fix

- `PestDestroyer.start` now seeds the navigation's trusted plot from the plot the lifecycle hands over, when the chat confirmation for it is fresh. Same trust the destroyer already gives its own confirmed teleports.
- The `PEST_PLOT_TP_FOR_CURRENT_PLOT` force-skip used a 3s chat window, which would also re-teleport off the roof if the PRE stage took longer than that. Now uses the normal 10s freshness window.
- Pulled the duplicated trusted-plot bookkeeping into `PestNavigationState.trustPlot`.

## Tested

In game over ~10 pest runs. Debug log now shows `Already on plot N, but AOTV to roof needed` → `no roof detected above player. Aborting AOTV` → hunting, with zero re-teleports, AOTV timeouts or no-progress aborts, including the exact case that failed before (plottp from plot 23 to 17 with the sidebar still showing 23).