### PR TITLE
Fix Pest Destroyer being slow, remove the need to use fireworks when a pest spawns in another plot, and prevent farming from stopping when /setspawn is used.

### DIFF
--- a/src/main/java/dev/aether/modules/pest/helpers/PestLifecycleManager.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestLifecycleManager.java
@@ -79,7 +79,8 @@ public final class PestLifecycleManager {
 
         boolean manualMode = AetherConfig.MANUAL_PEST_MODE.get();
         stage = Stage.PRE;
-        ClientUtils.sendDebugMessage("Pest lifecycle: waiting for /setspawn while farming continues.");
+        FarmingMacroManager.disable(client);
+        ClientUtils.sendDebugMessage("Pest lifecycle: farming stopped; waiting for /setspawn.");
         MacroWorkerThread.getInstance().submit("PestSetSpawn-" + plot, () -> {
             for (int attempt = 0; attempt < SETSPAWN_MAX_ATTEMPTS && isSetSpawnRetryPending(client, sessionId);
                     attempt++) {
@@ -88,11 +89,13 @@ public final class PestLifecycleManager {
                     return;
                 }
                 if (attempt + 1 < SETSPAWN_MAX_ATTEMPTS) {
-                    ClientUtils.sendDebugMessage("Pest lifecycle: /setspawn not confirmed; farming and retrying once.");
+                    ClientUtils.sendDebugMessage("Pest lifecycle: /setspawn not confirmed; retrying once.");
                 }
             }
             if (isSetSpawnRetryPending(client, sessionId)) {
                 ClientUtils.sendDebugMessage("Pest lifecycle: /setspawn failed twice; continuing farming.");
+                client.execute(() -> FarmingMacroManager.enable(
+                        client, FarmingMacroManager.createMacroFromConfig()));
                 PestManager.startPestReentryCooldown();
             }
             cancelPendingStart(sessionId);
@@ -108,7 +111,6 @@ public final class PestLifecycleManager {
         }
 
         ClientUtils.sendDebugMessage("Pest lifecycle: /setspawn confirmed; entering PRE stage for plot " + plot + ".");
-        FarmingMacroManager.disable(client);
         PestManager.setCleaningInProgress(true);
         PestManager.clearCleaningTriggerPending();
         LoadoutManager.shouldRestartFarmingAfterSwap = false;

--- a/src/main/java/dev/aether/modules/pest/helpers/PestPreStage.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestPreStage.java
@@ -2,6 +2,8 @@ package dev.aether.modules.pest.helpers;
 
 import dev.aether.config.AetherConfig;
 import dev.aether.macro.MacroWorkerThread;
+import dev.aether.modules.failsafe.FailsafeAction;
+import dev.aether.modules.failsafe.FailsafeManager;
 import dev.aether.modules.gear.GearManager;
 import dev.aether.modules.gear.helpers.LoadoutManager;
 import dev.aether.modules.pest.PestManager;
@@ -13,6 +15,10 @@ import net.minecraft.client.Minecraft;
  * Shared preparation for automatic and manual pest cleaning.
  */
 final class PestPreStage {
+
+    private static final long TARGET_PLOT_CONFIRM_TIMEOUT_MS = 10_000L;
+    private static final long PEST_ENTITY_LOAD_TIMEOUT_MS = 10_000L;
+    private static final long PEST_ENTITY_POLL_MS = 50L;
 
     record Result(boolean successful, PestBallsackShredder.Result ballsackResult) {
         static Result success() {
@@ -31,6 +37,14 @@ final class PestPreStage {
         if (shouldAbort(client, sessionId)) {
             return Result.failure();
         }
+        String pestNow = ClientUtils.getCurrentPlot();
+        boolean startedOnTargetPlot = PestPlotId.isUsable(pestNow)
+                && PestPlotId.equals(pestNow, plot);
+        boolean waitForRemotePestLoad = PestPlotId.isUsable(plot) && !startedOnTargetPlot;
+
+        ClientUtils.sendDebugMessage("Pest PRE stage: pestNow=" + pestNow
+                + ", targetPlot=" + plot
+                + ", remote=" + waitForRemotePestLoad + ".");
 
         if (AetherConfig.SUNSET_PESTS.get()) {
             if (!PestLifecycleManager.prepareSunsetPestsDaytime(client)) {
@@ -53,9 +67,85 @@ final class PestPreStage {
                     PestBallsackShredder.run(client, sessionId, pestCount);
             return new Result(result.successful(), result);
         }
-        return moveToRoofIfNeeded(client, plot, sessionId)
-                ? Result.success()
-                : Result.failure();
+
+        if (!moveToRoofIfNeeded(client, plot, sessionId)) {
+            return Result.failure();
+        }
+
+        if (waitForRemotePestLoad && !waitForTargetPlotAndPestLoad(client, plot, sessionId)) {
+            return Result.failure();
+        }
+
+        return Result.success();
+    }
+
+
+    private static boolean waitForTargetPlotAndPestLoad(
+            Minecraft client, String plot, int sessionId) throws InterruptedException {
+        long arrivalStartedAt = System.currentTimeMillis();
+        while (!isCurrentPlot(client, plot)) {
+            if (shouldAbort(client, sessionId)) {
+                return false;
+            }
+            if (System.currentTimeMillis() - arrivalStartedAt >= TARGET_PLOT_CONFIRM_TIMEOUT_MS) {
+                triggerPestPreFailsafe(
+                        client,
+                        "Pest PRE: target plot " + plot + " was not confirmed within 10 seconds.",
+                        "PestPreStage: timed out waiting for target plot " + plot);
+                return false;
+            }
+            MacroWorkerThread.sleep(PEST_ENTITY_POLL_MS);
+        }
+
+        ClientUtils.sendDebugMessage("Pest PRE stage: confirmed arrival on plot " + plot
+                + "; waiting for a loaded pest entity.");
+
+        long pestLoadStartedAt = System.currentTimeMillis();
+        while (true) {
+            if (shouldAbort(client, sessionId)) {
+                return false;
+            }
+
+            String currentPlot = ClientUtils.getCurrentPlot();
+            if (PestPlotId.isUsable(currentPlot) && !PestPlotId.equals(currentPlot, plot)) {
+                triggerPestPreFailsafe(
+                        client,
+                        "Pest PRE: left target plot " + plot + " while waiting for pest entities.",
+                        "PestPreStage: current plot changed to " + currentPlot
+                                + " while waiting for pests on " + plot);
+                return false;
+            }
+
+            int loadedPests = PestTargetTracker.getLoadedPests(client).size();
+            if (loadedPests > 0) {
+                ClientUtils.sendDebugMessage("Pest PRE stage: detected " + loadedPests
+                        + " loaded pest(s) on plot " + plot + "; entering PestDestroyer.");
+                return true;
+            }
+
+            if (System.currentTimeMillis() - pestLoadStartedAt >= PEST_ENTITY_LOAD_TIMEOUT_MS) {
+                triggerPestPreFailsafe(
+                        client,
+                        "Pest PRE: no pest entity loaded within 10 seconds on plot " + plot + ".",
+                        "PestPreStage: pest entity load timeout on plot " + plot);
+                return false;
+            }
+            MacroWorkerThread.sleep(PEST_ENTITY_POLL_MS);
+        }
+    }
+
+    private static boolean isCurrentPlot(Minecraft client, String plot) {
+        String currentPlot = ClientUtils.getCurrentPlot();
+        return PestPlotId.isUsable(currentPlot) && PestPlotId.equals(currentPlot, plot);
+    }
+
+    private static void triggerPestPreFailsafe(Minecraft client, String details, String debugReason) {
+        ClientUtils.sendDebugMessage(debugReason);
+        PestClientThread.run(client, () -> FailsafeManager.handleConfiguredAction(
+                client,
+                FailsafeAction.STOP,
+                details,
+                debugReason));
     }
 
     private static boolean moveToTargetPlot(Minecraft client, String plot, int sessionId) {


### PR DESCRIPTION
1. Pest Destroyer when the infested plot is different from the farming plot

When a pest spawns in a plot different from the one you are currently farming, the PreStage will teleport to the infested plot and immediately switch to the Pest Destroyer. At this point, the pest has not spawned yet, but the Pest Destroyer will continuously scan for the pest, causing it to fail and fall back to using a firework. This significantly increases the time it takes to clear the pest.

I modified the PreStage so that when the infested plot is different from the plot you are currently farming, it will teleport to the infested plot and wait until the pest actually spawns before activating the Pest Destroyer. This allows the Pest Destroyer to load the pest more reliably and quickly.

2. Stopping movement when using /setspawn

Since the /setspawn point is located away from the last farming position, when the mod warps back to the Garden and left-clicks to resume farming, it will initially hit the air. For a normal player, doing this would cause the hoe to take a few ticks before actually hitting the block. However, with Aether, even though it initially hits the air, it can break the block immediately without waiting those few ticks. This makes the behavior look quite unnatural.

Therefore, I changed the behavior so that farming movement stops when a pest spawns. This does not increase or decrease your profit; it simply makes the behavior look more legitimate and also helps the Pest Destroyer operate more reliably.

This also works together with the changes mentioned above, because the new logic gets the plot you are currently in immediately after /setspawn, preventing the Pest Destroyer from failing to load the pest and falling back to using a firework.