### PR TITLE
normal farming pest handling

### DIFF
--- a/src/main/java/dev/aether/config/AetherConfig.java
+++ b/src/main/java/dev/aether/config/AetherConfig.java
@@ -493,6 +493,10 @@ public final class AetherConfig {
         public static final BooleanEntry MANUAL_PEST_MODE = Config.bool("manualPestMode", false);
         public static final BooleanEntry VACCUM_WHEN_START = Config.bool("vaccumwhenstart", false);
         public static final StringEntry MANUAL_PEST_SOUND_FILE = Config.string("manualPestSoundFile", "fnaf.mp3");
+        public static final BooleanEntry NORMAL_FARMING_PEST_HANDLING =
+                        Config.bool("normalFarmingPestHandling", false);
+        public static final BooleanEntry NORMAL_FARMING_MANUAL_KILL =
+                        Config.bool("normalFarmingManualKill", true);
 
         // -- PEST EXCHANGE ---------------------------------------------------------
 

--- a/src/main/java/dev/aether/modules/pest/ManualPestManager.java
+++ b/src/main/java/dev/aether/modules/pest/ManualPestManager.java
@@ -30,6 +30,12 @@ public final class ManualPestManager {
     private ManualPestManager() {
     }
 
+    public static boolean isManualModeEnabled() {
+        return AetherConfig.MANUAL_PEST_MODE.get()
+                || (AetherConfig.NORMAL_FARMING_PEST_HANDLING.get()
+                        && AetherConfig.NORMAL_FARMING_MANUAL_KILL.get());
+    }
+
     public static void reset() {
         phase = Phase.IDLE;
         waitingStartedAt = 0L;
@@ -44,7 +50,7 @@ public final class ManualPestManager {
     public static void requestEarlyFinish(Minecraft client) {
         if (client == null
                 || phase != Phase.WAITING
-                || !AetherConfig.MANUAL_PEST_MODE.get()
+                || !isManualModeEnabled()
                 || MacroStateManager.getCurrentState() != MacroState.State.CLEANING
                 || !PestManager.isCleaningInProgress()) {
             return;
@@ -55,7 +61,7 @@ public final class ManualPestManager {
     }
 
     public static boolean startCleaningStage(Minecraft client, int count) {
-        if (!AetherConfig.MANUAL_PEST_MODE.get() || phase != Phase.IDLE) {
+        if (!isManualModeEnabled() || phase != Phase.IDLE) {
             return false;
         }
         if (client == null || client.player == null || client.getConnection() == null) {
@@ -74,7 +80,7 @@ public final class ManualPestManager {
         if (client == null || client.player == null || client.getConnection() == null) {
             return;
         }
-        if (!AetherConfig.MANUAL_PEST_MODE.get()) {
+        if (!isManualModeEnabled()) {
             if (phase != Phase.IDLE) {
                 phase = Phase.IDLE;
                 waitingStartedAt = 0L;

--- a/src/main/java/dev/aether/modules/pest/helpers/PestLifecycleManager.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestLifecycleManager.java
@@ -77,7 +77,7 @@ public final class PestLifecycleManager {
             return false;
         }
 
-        boolean manualMode = AetherConfig.MANUAL_PEST_MODE.get();
+        boolean manualMode = ManualPestManager.isManualModeEnabled();
         stage = Stage.PRE;
         ClientUtils.sendDebugMessage("Pest lifecycle: waiting for /setspawn while farming continues.");
         MacroWorkerThread.getInstance().submit("PestSetSpawn-" + plot, () -> {

--- a/src/main/java/dev/aether/modules/pest/helpers/PestPrepSwapManager.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestPrepSwapManager.java
@@ -38,7 +38,8 @@ public class PestPrepSwapManager {
 
     public static void updatePrepSwapFlag(int cooldownSeconds, boolean isCleaningInProgress,
             boolean thresholdMet) {
-        if (cooldownSeconds > getPrepSwapResetCooldownSeconds()
+        if ((AetherConfig.NORMAL_FARMING_PEST_HANDLING.get()
+                || cooldownSeconds > getPrepSwapResetCooldownSeconds())
                 && prepSwappedForCurrentPestCycle
                 && !isCleaningInProgress) {
             if (thresholdMet) {
@@ -51,6 +52,9 @@ public class PestPrepSwapManager {
 
     public static boolean shouldTriggerPrepSwap(MacroState.State currentState, int cooldownSeconds,
             boolean isCleaningInProgress, boolean isReturnToLocationActive) {
+        if (AetherConfig.NORMAL_FARMING_PEST_HANDLING.get()) {
+            return false;
+        }
         if (currentState != MacroState.State.FARMING) {
             return false;
         }

--- a/src/main/java/dev/aether/ui/providers/modules/PestManagerRegistryProvider.java
+++ b/src/main/java/dev/aether/ui/providers/modules/PestManagerRegistryProvider.java
@@ -3,6 +3,7 @@ package dev.aether.ui.providers.modules;
 import dev.aether.bootstrap.AetherKeybindRegistry;
 import dev.aether.config.AetherConfig;
 import dev.aether.modules.failsafe.FailsafeSoundManager;
+import dev.aether.modules.pest.ManualPestManager;
 import dev.aether.notification.NotificationManager;
 import dev.aether.ui.MainGUIRegistry;
 import dev.aether.ui.providers.base.AbstractModulesRegistryProvider;
@@ -146,6 +147,21 @@ public final class PestManagerRegistryProvider extends AbstractModulesRegistryPr
                 .add(FarmingSettingsFactory.pestFovRangeSetting())
                 .add(FarmingSettingsFactory.pestAboveAimPitchRangeSetting())
                 .add(FarmingSettingsFactory.pestMaxTurnSpeedSetting()));
+        groups.add(SettingGroup.of(
+                        "Normal Farming Pest Handling",
+                        "Farms normally through pest cooldowns without swapping to the pest spawn loadout. Pests are handled only once the Pest Threshold is reached",
+                        () -> AetherConfig.NORMAL_FARMING_PEST_HANDLING.get(),
+                        v -> {
+                            AetherConfig.NORMAL_FARMING_PEST_HANDLING.set(v);
+                            AetherConfig.save();
+                        })
+                .add(new ToggleSetting("Manual Pest Kill Mode",
+                        () -> AetherConfig.NORMAL_FARMING_MANUAL_KILL.get(),
+                        v -> {
+                            AetherConfig.NORMAL_FARMING_MANUAL_KILL.set(v);
+                            AetherConfig.save();
+                        })
+                        .visibleWhen(() -> AetherConfig.NORMAL_FARMING_PEST_HANDLING.get())));
         groups.add(SettingGroup.of(
                         "Pest Hunting",
                         "Lassos pests for guaranteed shards instead of vacuuming them (needs a lasso in your hotbar)",
@@ -298,14 +314,14 @@ public final class PestManagerRegistryProvider extends AbstractModulesRegistryPr
                             AetherConfig.VACCUM_WHEN_START.set(v);
                             AetherConfig.save();
                         })
-                        .visibleWhen(() -> AetherConfig.MANUAL_PEST_MODE.get()))
+                        .visibleWhen(() -> ManualPestManager.isManualModeEnabled()))
                 .add(new ToggleSetting("Auto Alt-Tab",
                         () -> AetherConfig.FAILSAFE_AUTO_ALT_TAB.get(),
                         v -> {
                             AetherConfig.FAILSAFE_AUTO_ALT_TAB.set(v);
                             AetherConfig.save();
                         })
-                        .visibleWhen(() -> AetherConfig.MANUAL_PEST_MODE.get()))
+                        .visibleWhen(() -> ManualPestManager.isManualModeEnabled()))
                 .add(new DropdownSetting("Manual Pest Sound", manualPestSoundOptions,
                         () -> getSoundIndex(manualPestSoundOptions, AetherConfig.MANUAL_PEST_SOUND_FILE.get()),
                         i -> {


### PR DESCRIPTION
makes normal farming not suck

won't swap loadouts to prep spawning pests, keeps you farming until the pest threshold is reached, then handles them via manual kill or pest destroyer (new toggle, default off)