### PR TITLE
normal farming pest handling

### DIFF
--- a/src/main/java/dev/aether/config/AetherConfig.java
+++ b/src/main/java/dev/aether/config/AetherConfig.java
@@ -493,6 +493,8 @@ public final class AetherConfig {
         public static final BooleanEntry MANUAL_PEST_MODE = Config.bool("manualPestMode", false);
         public static final BooleanEntry VACCUM_WHEN_START = Config.bool("vaccumwhenstart", false);
         public static final StringEntry MANUAL_PEST_SOUND_FILE = Config.string("manualPestSoundFile", "fnaf.mp3");
+        public static final BooleanEntry NORMAL_FARMING_PEST_HANDLING =
+                        Config.bool("normalFarmingPestHandling", false);
 
         // -- PEST EXCHANGE ---------------------------------------------------------
 

--- a/src/main/java/dev/aether/modules/pest/helpers/PestPrepSwapManager.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/PestPrepSwapManager.java
@@ -38,7 +38,8 @@ public class PestPrepSwapManager {
 
     public static void updatePrepSwapFlag(int cooldownSeconds, boolean isCleaningInProgress,
             boolean thresholdMet) {
-        if (cooldownSeconds > getPrepSwapResetCooldownSeconds()
+        if ((AetherConfig.NORMAL_FARMING_PEST_HANDLING.get()
+                || cooldownSeconds > getPrepSwapResetCooldownSeconds())
                 && prepSwappedForCurrentPestCycle
                 && !isCleaningInProgress) {
             if (thresholdMet) {
@@ -51,6 +52,9 @@ public class PestPrepSwapManager {
 
     public static boolean shouldTriggerPrepSwap(MacroState.State currentState, int cooldownSeconds,
             boolean isCleaningInProgress, boolean isReturnToLocationActive) {
+        if (AetherConfig.NORMAL_FARMING_PEST_HANDLING.get()) {
+            return false;
+        }
         if (currentState != MacroState.State.FARMING) {
             return false;
         }

--- a/src/main/java/dev/aether/ui/providers/modules/PestManagerRegistryProvider.java
+++ b/src/main/java/dev/aether/ui/providers/modules/PestManagerRegistryProvider.java
@@ -321,6 +321,15 @@ public final class PestManagerRegistryProvider extends AbstractModulesRegistryPr
                         AetherKeybindRegistry.getManualPestEarlyFinishKey())));
 
         groups.add(SettingGroup.of(
+                        "Normal Farming Pest Handling",
+                        "Farms normally through pest cooldowns without swapping to the pest spawn loadout. Pests are handled only once the Pest Threshold is reached, following your Manual Pest Mode / Pest Destroyer setting",
+                        () -> AetherConfig.NORMAL_FARMING_PEST_HANDLING.get(),
+                        v -> {
+                            AetherConfig.NORMAL_FARMING_PEST_HANDLING.set(v);
+                            AetherConfig.save();
+                        }));
+
+        groups.add(SettingGroup.of(
                         "Pest Traps",
                         "Clears and refills pest traps",
                         () -> AetherConfig.ENABLE_PEST_TRAPS.get(),


### PR DESCRIPTION
won't swap loadouts to prep spawning pests, keeps you farming until the pest threshold is reached, then handles them via manual pest mode or pest destroyer (ONE new toggle, default off) 