### PR TITLE
feat: experimental human-cursor (WindMouse) pest aim + tracking test commands

### DIFF
--- a/src/main/java/dev/aether/bootstrap/AetherCommandRegistrar.java
+++ b/src/main/java/dev/aether/bootstrap/AetherCommandRegistrar.java
@@ -33,6 +33,7 @@ import dev.aether.modules.visitor.VisitorsMacro;
 import dev.aether.util.AetherLang;
 import dev.aether.util.BazaarUtils;
 import dev.aether.util.ClientUtils;
+import dev.aether.modules.pest.helpers.TestTrackManager;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommands;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
 import net.fabricmc.fabric.api.client.message.v1.ClientSendMessageEvents;
@@ -143,6 +144,22 @@ public final class AetherCommandRegistrar {
                                     .executes(ctx -> TablistSetupManager.start(Minecraft.getInstance())))
                             .then(ClientCommands.literal("printscoreboard")
                                     .executes(ctx -> printScoreboard(Minecraft.getInstance())))
+                            .then(ClientCommands.literal("testtrack")
+                                    .executes(ctx -> {
+                                        boolean on = TestTrackManager.toggleHuman();
+                                        ClientUtils.sendMessage(on
+                                                ? "§aTest track (human) ON – pursuing nearest pest (no clicking)."
+                                                : "§eTest track OFF.", false);
+                                        return 1;
+                                    }))
+                            .then(ClientCommands.literal("testoriginal")
+                                    .executes(ctx -> {
+                                        boolean on = TestTrackManager.toggleOriginal();
+                                        ClientUtils.sendMessage(on
+                                                ? "§bTest track (original) ON – in-game combat tracking (no clicking)."
+                                                : "§eTest track OFF.", false);
+                                        return 1;
+                                    }))
                             .then(ClientCommands.literal("rotate")
                                     .then(ClientCommands.argument("pitch", FloatArgumentType.floatArg(-90.0f, 90.0f))
                                             .suggests((ctx, builder) -> suggestAngles(builder, "-90", "-45", "0", "45", "90"))
@@ -432,6 +449,26 @@ public final class AetherCommandRegistrar {
                                             .then(ClientCommands.argument("config_string", StringArgumentType.greedyString())
                                                     .executes(ctx -> importConfig(
                                                             StringArgumentType.getString(ctx, "config_string")))))));
+
+            dispatcher.register(
+                    ClientCommands.literal("testtrack")
+                            .executes(ctx -> {
+                                boolean on = TestTrackManager.toggleHuman();
+                                ClientUtils.sendMessage(on
+                                        ? "§aTest track (human) ON – pursuing nearest pest (no clicking)."
+                                        : "§eTest track OFF.", false);
+                                return 1;
+                            }));
+
+            dispatcher.register(
+                    ClientCommands.literal("testoriginal")
+                            .executes(ctx -> {
+                                boolean on = TestTrackManager.toggleOriginal();
+                                ClientUtils.sendMessage(on
+                                        ? "§bTest track (original) ON – in-game combat tracking (no clicking)."
+                                        : "§eTest track OFF.", false);
+                                return 1;
+                            }));
         });
     }
 

--- a/src/main/java/dev/aether/bootstrap/AetherTickHandlers.java
+++ b/src/main/java/dev/aether/bootstrap/AetherTickHandlers.java
@@ -18,6 +18,8 @@ public final class AetherTickHandlers {
         MovementPlaybackManager.register();
         FreecamManager.register();
         FreelookManager.register();
+        net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents.END_CLIENT_TICK
+                .register(dev.aether.modules.pest.helpers.TestTrackManager::tick);
     }
 
     public static void setPickingUpStash(boolean pickingUpStash) {

--- a/src/main/java/dev/aether/config/AetherConfig.java
+++ b/src/main/java/dev/aether/config/AetherConfig.java
@@ -663,6 +663,10 @@ public final class AetherConfig {
         public static final FloatEntry ROTATION_EASE_IN_FACTOR = Config.floatVal("rotationEaseInFactor", 2.0f).range(1.0f, 5.0f);
         public static final BooleanEntry ROTATION_EASE_OUT = Config.bool("rotationEaseOut", true);
         public static final FloatEntry ROTATION_EASE_OUT_FACTOR = Config.floatVal("rotationEaseOutFactor", 2.0f).range(1.0f, 5.0f);
+        // WindMouse ("human cursor") aim for the point-to-point turn onto a pest.
+        public static final BooleanEntry ROTATION_HUMAN_CURSOR = Config.bool("rotationHumanCursor", false);
+        public static final FloatEntry ROTATION_HC_GRAVITY = Config.floatVal("rotationHcGravity", 9.0f).range(3.0f, 20.0f);
+        public static final FloatEntry ROTATION_HC_WIND = Config.floatVal("rotationHcWind", 3.0f).range(0.0f, 12.0f);
         public static final FloatEntry ROTATION_TRACKING_NOISE_MIN = Config.floatVal("rotationTrackingNoiseMin", 2.0f)
                         .range(0.0f, 10.0f);
         public static final FloatEntry ROTATION_TRACKING_NOISE_MAX = Config.floatVal("rotationTrackingNoiseMax", 6.0f)

--- a/src/main/java/dev/aether/modules/pest/helpers/TestTrackManager.java
+++ b/src/main/java/dev/aether/modules/pest/helpers/TestTrackManager.java
@@ -1,0 +1,81 @@
+package dev.aether.modules.pest.helpers;
+
+import dev.aether.config.AetherConfig;
+import dev.aether.modules.rotation.RotationManager;
+import net.minecraft.client.Minecraft;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.phys.Vec3;
+
+/**
+ * Temporary test aid for comparing pest aim feel without clicking or interacting.
+ * {@code /testtrack} runs a smoother experimental pursuit; {@code /testoriginal}
+ * runs the current in-game combat tracking smoothing as a baseline. Tracking
+ * pauses whenever a screen is open so chat can be used to toggle it back off.
+ */
+public final class TestTrackManager {
+    private static final float ORIGINAL_SMOOTHING_MS = 190.0f;
+    private static final float HUMAN_SMOOTHING_MS = 130.0f;
+
+    private enum Mode { OFF, HUMAN, ORIGINAL }
+
+    private static Mode mode = Mode.OFF;
+
+    private TestTrackManager() {
+    }
+
+    public static boolean toggleHuman() {
+        mode = (mode == Mode.HUMAN) ? Mode.OFF : Mode.HUMAN;
+        if (mode == Mode.OFF) {
+            RotationManager.cancelRotation();
+        }
+        return mode == Mode.HUMAN;
+    }
+
+    public static boolean toggleOriginal() {
+        mode = (mode == Mode.ORIGINAL) ? Mode.OFF : Mode.ORIGINAL;
+        if (mode == Mode.OFF) {
+            RotationManager.cancelRotation();
+        }
+        return mode == Mode.ORIGINAL;
+    }
+
+    public static void tick(Minecraft client) {
+        if (mode == Mode.OFF || client == null || client.player == null || client.level == null) {
+            return;
+        }
+        // Pause while any screen is open so chat can be used to toggle it off and
+        // the camera does not fight the player's input.
+        if (client.screen != null) {
+            RotationManager.cancelRotation();
+            return;
+        }
+        Entity nearest = nearestPest(client);
+        if (nearest == null) {
+            RotationManager.cancelRotation();
+            return;
+        }
+        float smoothing = (mode == Mode.ORIGINAL) ? ORIGINAL_SMOOTHING_MS : HUMAN_SMOOTHING_MS;
+        RotationManager.trackRotation(
+                client,
+                nearest.getEyePosition(),
+                smoothing,
+                AetherConfig.PEST_MAX_TURN_SPEED.get());
+    }
+
+    private static Entity nearestPest(Minecraft client) {
+        Vec3 eye = client.player.getEyePosition();
+        Entity best = null;
+        double bestSq = Double.MAX_VALUE;
+        for (Entity entity : PestTargetTracker.getLoadedPestMobs(client)) {
+            if (entity == null || entity.isRemoved()) {
+                continue;
+            }
+            double distSq = entity.position().distanceToSqr(eye);
+            if (distSq < bestSq) {
+                bestSq = distSq;
+                best = entity;
+            }
+        }
+        return best;
+    }
+}

--- a/src/main/java/dev/aether/modules/rotation/RotationManager.java
+++ b/src/main/java/dev/aether/modules/rotation/RotationManager.java
@@ -34,6 +34,21 @@ public class RotationManager {
     private static boolean trackingMode = false;
     private static float trackingSmoothingMs = 0.0f;
 
+    // WindMouse ("human cursor") state for the point-to-point turn onto a target.
+    private static final double SQRT3 = Math.sqrt(3.0);
+    private static final double SQRT5 = Math.sqrt(5.0);
+    private static final double WIND_ITER_MS = 6.0;
+    private static final double WIND_DAMP_DISTANCE = 8.0;
+    private static final double WIND_MAX_STEP = 2.5;
+    private static final double WIND_ARRIVAL_DEGREES = 0.35;
+    private static boolean windMode = false;
+    private static double windYaw = 0.0;
+    private static double windPitch = 0.0;
+    private static double windVx = 0.0;
+    private static double windVy = 0.0;
+    private static double windWx = 0.0;
+    private static double windWy = 0.0;
+
     public static boolean isRotating() {
         return isRotating;
     }
@@ -49,6 +64,7 @@ public class RotationManager {
         hasLastApplied = false;
         maxDegreesPerSecond = 0.0f;
         trackingMode = false;
+        windMode = false;
     }
 
     public static void initiateRotation(Minecraft mc, Vec3 targetPos, long minDuration) {
@@ -93,6 +109,15 @@ public class RotationManager {
         hasLastApplied = false;
         maxDegreesPerSecond = Math.max(0.0f, turnSpeedLimit);
         trackingMode = false;
+        windMode = AetherConfig.ROTATION_HUMAN_CURSOR.get();
+        if (windMode) {
+            windYaw = startRot.yaw;
+            windPitch = startRot.pitch;
+            windVx = 0.0;
+            windVy = 0.0;
+            windWx = 0.0;
+            windWy = 0.0;
+        }
         isRotating = true;
     }
 
@@ -118,6 +143,7 @@ public class RotationManager {
         hasLastApplied = false;
         maxDegreesPerSecond = 0.0f;
         trackingMode = false;
+        windMode = false;
         isRotating = true;
     }
 
@@ -138,6 +164,7 @@ public class RotationManager {
         hasLastApplied = false;
         maxDegreesPerSecond = 0.0f;
         trackingMode = false;
+        windMode = false;
         isRotating = true;
     }
 
@@ -166,6 +193,7 @@ public class RotationManager {
         maxDegreesPerSecond = Math.max(0.0f, turnSpeedLimit);
         trackingSmoothingMs = Math.max(MIN_TRACKING_SMOOTHING_MS, smoothingMs);
         trackingMode = true;
+        windMode = false;
         isRotating = true;
     }
 
@@ -199,6 +227,50 @@ public class RotationManager {
                 float closed = 1.0f - (float) Math.exp(-stepMs / trackingSmoothingMs);
                 currentYaw = mc.player.getYRot() + remainingYaw * closed;
                 currentPitch = mc.player.getXRot() + remainingPitch * closed;
+            } else if (windMode) {
+                double dyaw = targetRot.yaw - windYaw;
+                double dpitch = targetRot.pitch - windPitch;
+                double dist = Math.sqrt(dyaw * dyaw + dpitch * dpitch);
+                if (dist <= WIND_ARRIVAL_DEGREES) {
+                    windYaw = targetRot.yaw;
+                    windPitch = targetRot.pitch;
+                    isRotating = false;
+                } else {
+                    double gravity = AetherConfig.ROTATION_HC_GRAVITY.get();
+                    double windStrength = AetherConfig.ROTATION_HC_WIND.get();
+                    int iters = (int) Math.max(1L, Math.round(stepMs / WIND_ITER_MS));
+                    ThreadLocalRandom rnd = ThreadLocalRandom.current();
+                    for (int i = 0; i < iters; i++) {
+                        dyaw = targetRot.yaw - windYaw;
+                        dpitch = targetRot.pitch - windPitch;
+                        dist = Math.sqrt(dyaw * dyaw + dpitch * dpitch);
+                        if (dist < 1.0) {
+                            break;
+                        }
+                        double windMag = Math.min(windStrength, dist);
+                        double maxStep = WIND_MAX_STEP;
+                        if (dist >= WIND_DAMP_DISTANCE) {
+                            windWx = windWx / SQRT3 + (2.0 * rnd.nextDouble() - 1.0) * windMag / SQRT5;
+                            windWy = windWy / SQRT3 + (2.0 * rnd.nextDouble() - 1.0) * windMag / SQRT5;
+                        } else {
+                            windWx /= SQRT3;
+                            windWy /= SQRT3;
+                            maxStep = 0.6 + (WIND_MAX_STEP - 0.6) * (dist / WIND_DAMP_DISTANCE);
+                        }
+                        windVx += windWx + gravity * dyaw / dist;
+                        windVy += windWy + gravity * dpitch / dist;
+                        double vmag = Math.sqrt(windVx * windVx + windVy * windVy);
+                        if (vmag > maxStep) {
+                            double vclip = maxStep / 2.0 + rnd.nextDouble() * maxStep / 2.0;
+                            windVx = windVx / vmag * vclip;
+                            windVy = windVy / vmag * vclip;
+                        }
+                        windYaw += windVx;
+                        windPitch += windVy;
+                    }
+                }
+                currentYaw = (float) windYaw;
+                currentPitch = (float) windPitch;
             } else {
                 long elapsed = updateAt - rotationStartTime;
                 float t = (float) elapsed / (float) rotationDuration;

--- a/src/main/java/dev/aether/ui/providers/modules/HumanizationRegistryProvider.java
+++ b/src/main/java/dev/aether/ui/providers/modules/HumanizationRegistryProvider.java
@@ -93,6 +93,28 @@ public final class HumanizationRegistryProvider extends AbstractModulesRegistryP
                         })
                         .withDecimals(1)
                         .visibleWhen(() -> AetherConfig.ROTATION_EASE_OUT.get()))
+                .add(new ToggleSetting("Human Cursor Aim",
+                        () -> AetherConfig.ROTATION_HUMAN_CURSOR.get(),
+                        v -> {
+                            AetherConfig.ROTATION_HUMAN_CURSOR.set(v);
+                            AetherConfig.save();
+                        }))
+                .add(new SliderSetting("Human Cursor Gravity", 3, 20,
+                        () -> AetherConfig.ROTATION_HC_GRAVITY.get(),
+                        v -> {
+                            AetherConfig.ROTATION_HC_GRAVITY.set(v);
+                            AetherConfig.save();
+                        })
+                        .withDecimals(1)
+                        .visibleWhen(() -> AetherConfig.ROTATION_HUMAN_CURSOR.get()))
+                .add(new SliderSetting("Human Cursor Wind", 0, 12,
+                        () -> AetherConfig.ROTATION_HC_WIND.get(),
+                        v -> {
+                            AetherConfig.ROTATION_HC_WIND.set(v);
+                            AetherConfig.save();
+                        })
+                        .withDecimals(1)
+                        .visibleWhen(() -> AetherConfig.ROTATION_HUMAN_CURSOR.get()))
                 .add(new SliderSetting("Tracking Noise Min", 0, 10,
                         () -> AetherConfig.ROTATION_TRACKING_NOISE_MIN.get(),
                         v -> {


### PR DESCRIPTION
## Summary

Experimental work toward making the pest aim/turning look more human. Two parts, both **opt-in** and off by default, so nothing changes for existing users unless they enable it.

### 1. Human Cursor Aim (WindMouse) — the point-to-point turn onto a pest

Instead of easing each axis straight to the target, the turn is driven by the **WindMouse** algorithm: `(yaw, pitch)` is treated as one 2D point pulled by *gravity* toward the pest plus a decaying random *wind* force, with velocity clamping. The crosshair **arcs** onto the pest and settles, rather than sliding in a straight diagonal. Mouse-GCD quantization and the existing turn-speed limit still apply on top.

Controls (Settings → Humanization):
- **Human Cursor Aim** — toggle (default **off**)
- **Human Cursor Gravity** (3–20, default 9) — higher = straighter/faster pull
- **Human Cursor Wind** (0–12, default 3) — higher = more curve/wander

### 2. Temporary test commands (left in on purpose, for testers)

So people can feel and compare the tracking without a full pest run — **neither clicks or interacts, camera only**:

- **`/testtrack`** — smoother experimental pursuit of the nearest pest
- **`/testoriginal`** — the current in-game combat tracking smoothing (baseline for comparison)

Both continuously pursue the nearest loaded pest and **pause whenever a screen is open**, so you can open chat and type the command again to toggle them off. (Also available as `/aether testtrack` and `/aether testoriginal`.)

## Known issue — tracking jitter (feedback wanted)

While tracking you'll notice a fine **jitter**. That's the existing **tracking noise** humanization (`ROTATION_TRACKING_NOISE_MIN`/`MAX`, ~2–6%) re-rolled every rendered frame, not a bug. It's tunable live in Settings → Humanization (**Tracking Noise Min/Max**) — set both to 0 to remove it entirely.

**We're honestly not sure how much of that noise is actually needed** for anti-pattern-detection vs. how much just reads as buzzy. 

## Asking for improvements — specifically smoothness

The main thing we'd love help/feedback on is **smoothness of the tracking**. The frame-jitter noise and the WindMouse wander are two different mechanisms; ideally the human-looking motion comes from smooth, correlated movement (wind-style) rather than per-frame random jitter. Suggestions, tuning, or a better tracking model very welcome.

## Notes
- Additive only (+218 lines across 6 files), no behavior change unless the toggle/commands are used.
- Test commands are intentionally temporary and can be stripped before any final merge.